### PR TITLE
handle compressed files

### DIFF
--- a/dpytools/s3/basic.py
+++ b/dpytools/s3/basic.py
@@ -89,12 +89,12 @@ def decompress_s3_tar(
             f"This function currently only handles archives using the tar extension. Got {object_name}"
         )
 
-    bucket_name = object_name.split("/")[0]
-    object_key = "/".join(object_name.split("/")[1:])
-
     if isinstance(directory, str):
         directory = Path(directory)
     directory.mkdir(parents=True, exist_ok=True)
+
+    bucket_name = object_name.split("/")[0]
+    object_key = "/".join(object_name.split("/")[1:])
 
     tmp_file = tempfile.NamedTemporaryFile()
     with open(tmp_file.name, "wb") as f:

--- a/dpytools/s3/basic.py
+++ b/dpytools/s3/basic.py
@@ -3,7 +3,6 @@ import tarfile
 import tempfile
 from pathlib import Path
 from typing import Optional, Union
-from io import BytesIO
 
 import boto3
 

--- a/dpytools/s3/basic.py
+++ b/dpytools/s3/basic.py
@@ -3,6 +3,7 @@ import tarfile
 import tempfile
 from pathlib import Path
 from typing import Optional, Union
+from io import BytesIO
 
 import boto3
 
@@ -89,16 +90,18 @@ def decompress_s3_tar(
             f"This function currently only handles archives using the tar extension. Got {object_name}"
         )
 
-    # Use tempfile so our tar file automagically dissapears after its been extracted from
-    tmp_tar = tempfile.NamedTemporaryFile()
-    download_s3_file_content_to_local(
-        object_name, tmp_tar.name, profile_name=profile_name
-    )
+    bucket_name = object_name.split("/")[0]
+    object_key = "/".join(object_name.split("/")[1:])
 
     if isinstance(directory, str):
         directory = Path(directory)
-    directory.parent.mkdir(parents=True, exist_ok=True)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    tmp_file = tempfile.NamedTemporaryFile()
+    with open(tmp_file.name, "wb") as f:
+        client = _get_s3_client(profile_name)
+        client.download_fileobj(bucket_name, object_key, f)
 
     # Decompress all the files to the directory specified.
-    with tarfile.open(tmp_tar.name, mode="r:*") as tar:
-        tar.extractall(directory)
+    with tarfile.open(tmp_file.name, mode="r:*") as tar:
+        tar.extractall(directory.absolute())

--- a/dpytools/stores/directory/base.py
+++ b/dpytools/stores/directory/base.py
@@ -25,7 +25,9 @@ class BaseReadableSingleDirectoryStore(ABC):
         ...
 
     @abstractmethod
-    def save_lone_file_matching(self, pattern: str, destination: Optional[Union[Path, str]]= None):
+    def save_lone_file_matching(
+        self, pattern: str, destination: Optional[Union[Path, str]] = None
+    ):
         """
         Assert 1 file matches
         Save it as the provided file to current path
@@ -40,8 +42,7 @@ class BaseReadableSingleDirectoryStore(ABC):
         Return the contents of the matching json as a dictionary.
         """
         ...
-        
-        
+
     @abstractmethod
     def get_file_names(self) -> List[str]:
         """

--- a/dpytools/stores/directory/local.py
+++ b/dpytools/stores/directory/local.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import json
 import os
 import re
-import json
 from pathlib import Path
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 from dpytools.stores.directory.base import BaseWritableSingleDirectoryStore
 
@@ -58,17 +58,23 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
         if len(matching_files) == 1:  # 1 file matched
             return True
         elif len(matching_files) == 0:  # 0 file matched
-            return False         
+            return False
         else:  # 2+ files matched
-            raise FileNotFoundError(f"More than 1 file found that matches the regex pattern '{pattern}' in directory {self.local_path}. Matching: {matching_files}")
+            raise FileNotFoundError(
+                f"More than 1 file found that matches the regex pattern '{pattern}' in directory {self.local_path}. Matching: {matching_files}"
+            )
 
-    def save_lone_file_matching(self, pattern: str, destination: Optional[Union[Path, str]] = None):
+    def save_lone_file_matching(
+        self, pattern: str, destination: Optional[Union[Path, str]] = None
+    ):
         """
         Asserts a file matches the given pattern, then saves it to the given destination.
         """
         # Assert 1 file matches
         if not self.has_lone_file_matching(pattern):
-            raise FileNotFoundError(f"No matching files found for pattern {pattern} in directory {self.local_path}")
+            raise FileNotFoundError(
+                f"No matching files found for pattern {pattern} in directory {self.local_path}"
+            )
 
         file_to_save = self._files_that_match_pattern(pattern)[0]
         file_name = Path(file_to_save).name
@@ -77,7 +83,9 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
         if destination is not None:
             if isinstance(destination, str):
                 destination = Path(destination)
-            assert destination.exists(), f"Destination directory {destination} does not exist."
+            assert (
+                destination.exists()
+            ), f"Destination directory {destination} does not exist."
             save_path = Path(destination / file_name)
         # If no destination is given, save the matched file in the current directory.
         else:
@@ -96,8 +104,10 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
 
     def get_lone_matching_json_as_dict(self, pattern: str) -> dict:
         # Assert 1 file matches
-        if self.has_lone_file_matching(pattern): 
-            file_path = Path(self.local_path / self._files_that_match_pattern(pattern)[0])
+        if self.has_lone_file_matching(pattern):
+            file_path = Path(
+                self.local_path / self._files_that_match_pattern(pattern)[0]
+            )
 
             # use json.load to put contents of file into variable and return dict.
             with open(file_path) as f:
@@ -108,17 +118,16 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
         """
         Returns a list of the files in the store.
         """
-        file_names = os.listdir(self.local_path) #grab list of full paths to files,
+        file_names = os.listdir(self.local_path)  # grab list of full paths to files,
         if len(file_names) == 0:
             return []
         else:
             return file_names
 
     def _files_that_match_pattern(self, pattern) -> List[str]:
-     # given a pattern, return a list of all files that match it.
-     # use self.get_files_names() in here as well.
-        matching_files = [
-            f for f in self.get_file_names() if re.search(pattern, f)]
+        # given a pattern, return a list of all files that match it.
+        # use self.get_files_names() in here as well.
+        matching_files = [f for f in self.get_file_names() if re.search(pattern, f)]
 
         return matching_files
 


### PR DESCRIPTION
### What

Quick fix for the s3 decompress function.

I _think_ when we ere developing this we were using a file with a ".tar" extension rather than a file that was compressed as a tar. this means then when I tried to decompress an actual tar file it failed with an encoding error.

I've just explicitly switched the logic so we:

- download the tar file to a temporary file
- untar it from there

because we're no longer using `download_s3_content_to_local` we don't get tripped by the ""utf-8"" assumption.

### How to review

Try it out. Will put a sample s3 object elsewhere (not in a public github repo)

```python
from dpytools.s3.basic import decompress_s3_tar

decompress_s3_tar("sample d3 object", "stuff")
```

Note: I've only actually changed about 3 lines in the function, the tests and documentation remain as is. Most of the changes are from running `make fmt` and `make lint`.

### Who can review

Anyone.