### PR TITLE
return path on save

### DIFF
--- a/dpytools/stores/directory/local.py
+++ b/dpytools/stores/directory/local.py
@@ -90,7 +90,7 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
 
     def save_lone_file_matching(
         self, pattern: str, destination: Optional[Union[Path, str]] = None
-    ):
+    ) -> Path:
         """
         Asserts a file matches the given pattern, then saves it to the given destination.
         """
@@ -125,6 +125,8 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
 
         with open(save_path, "w") as f:
             f.write(file_data)
+
+        return save_path
 
     def get_lone_matching_json_as_dict(self, pattern: str) -> dict:
         # Assert 1 file matches


### PR DESCRIPTION
### What

Updated the store to return the Path to where it just saved a file.

Needed to said file paths can be passed along where (for example) they're being used in the transform pipeline.

Because it takes a regex as an argument, without returning the path its hard to know exactly where we saved the file and as what name, hence this.

### How to review

Sanity check

### Who can review

Anyone