### PR TITLE
DIS721 update upload client

### DIFF
--- a/dpytools/http/README.md
+++ b/dpytools/http/README.md
@@ -70,45 +70,71 @@ response = http_client.post(
 
 If the `POST` request fails for a network-related reason, this will raise an `HTTPError`.
 
-### UploadClient
+### UploadServiceClient
 
-The `UploadClient` class facilitates the process of uploading a file to an AWS S3 bucket by splitting the file into chunks and transmitting these chunks individually. This is done via the `upload()` method.
+The `UploadServiceClient` class facilitates the process of uploading a file to an AWS S3 bucket by splitting the file into chunks and transmitting these chunks individually. It implements methods for uploading CSV and SDMX files to the DP Upload Service. Which method you use will depend on whether you are accessing the `/upload` or `upload-new` endpoint. Details on using each method are provided below.
 
-A new `UploadClient` object can be created by passing an `upload_url`:
+A new `UploadServiceClient` object can be created by passing an `upload_url`:
 
 ```python
-from dpytools.http.upload import UploadClient
+from dpytools.http.upload import UploadServiceClient
 
-upload_client = UploadClient(upload_url="http://example.org/upload")
+upload_client = UploadServiceClient(upload_url="http://example.org/upload")
 ```
 
-To access the DP Upload Service, a Florence access control token must be provided. For security purposes this should be set using an environment variable.
+To access the DP Upload Service, a Florence access control token must be provided. This should be generated via the DP Identity API.
 
-#### upload()
+#### upload_csv() and upload_sdmx()
 
-The `UploadClient` provides an `upload()` method which accepts a file to be uploaded, an S3 Bucket identifier, a Florence access token, and an optional chunk size (default value 5242880 bytes).
+To upload files to the `/upload` endpoint, use the `upload_csv()` and `upload_sdmx()` methods. Both of these methods accept a file to be uploaded, an S3 Bucket identifier, a Florence access token, and an optional chunk size with a default value of 5242880 bytes (5MB).
 
-The S3 Bucket identifier should be set as an environment variable. The Florence access token should be generated via the DP Identity API and passed as an argument to `upload()`.
-
-Calling the `upload()` method creates the temporary file chunks, uploads these to the `UploadClient.upload_url`, and finally deletes the temporary files. The method returns the S3 Object key and S3 URI of the Object's location:
+Calling these methods will create the temporary file chunks, upload these to the `UploadServiceClient.upload_url`, and finally delete the temporary files.
 
 ```python
-from dpytools.http.upload import UploadClient
+from dpytools.http.upload import UploadServiceClient
 
-upload_client = UploadClient("http://example.org/upload")
+upload_client = UploadServiceClient("http://example.org/upload")
 
-s3_bucket = os.getenv("S3_BUCKET")
+s3_bucket = "<s3-bucket-name-here>"
 florence_access_token = "<florence-access-token-here>"
 
-s3_key, s3_uri = upload_client.upload(
-    "path/to/countries.csv",
-    s3_bucket,
-    florence_access_token,
+upload_client.upload_csv(
+    csv_path="path/to/file.csv",
+    s3_bucket=s3_bucket,
+    florence_access_token=florence_access_token
 )
 
-# The s3_key is a unique identifier, and consists of the timestamp of when the upload process commenced and the filename of the uploaded file:
-# s3_key example: "110324094616-countries-csv"
+upload_client.upload_sdmx(
+    sdmx_path="path/to/file.sdmx",
+    s3_bucket=s3_bucket,
+    florence_access_token=florence_access_token
+)
+```
 
-# The s3_uri concatenates the s3_bucket and s3_key values:
-# s3_uri example: "s3://mybucket/110324094616-countries-csv"
+#### upload_new_csv() and upload_new_sdmx()
+
+To upload files to the `/upload-new` endpoint, use the `upload_new_csv()` and `upload_new_sdmx()` methods. Both of these methods accept a file to be uploaded, a Florence access token, and an optional chunk size with a default value of 5242880 bytes (5MB).
+
+The `/upload-new` endpoint also requires an `alias_name` and `title` to be provided in the HTTP request parameters. If these are not explicitly stated in the method call, `alias_name` will default to the filename with the extension, and `title` will default to the filename without the extension.
+
+```python
+from dpytools.http.upload import UploadServiceClient
+
+upload_client = UploadServiceClient("http://example.org/upload-new")
+
+florence_access_token = "<florence-access-token-here>"
+
+# `alias_name` and `title` arguments not provided, so these values will default to `file.csv` and `file` respectively.
+upload_client.upload_new_csv(
+    csv_path="path/to/file.csv",
+    florence_access_token=florence_access_token,
+)
+
+# `alias_name` and `title` arguments provided, so these values will be set explicitly.
+upload_client.upload_new_sdmx(
+    sdmx_path="path/to/file.sdmx",
+    florence_access_token=florence_access_token,
+    alias_name="my-awesome-file.sdmx",
+    title="My Awesome SDMX File"
+)
 ```

--- a/dpytools/http/base.py
+++ b/dpytools/http/base.py
@@ -1,13 +1,15 @@
-import logging
-
 import backoff
 import requests
 from requests.exceptions import HTTPError
 
+from dpytools.logging.logger import DpLogger
+
+logger = DpLogger("dpytools")
+
 
 # Function to log retry attempts
 def log_retry(details):
-    logging.error(f"Request failed, retrying... Attempt #{details['tries']}")
+    logger.warning(f"Request failed, retrying... Attempt #{details['tries']}")
 
 
 class BaseHttpClient:
@@ -69,19 +71,35 @@ class BaseHttpClient:
 
     # Method to handle requests for GET and POST
     def _handle_request(self, method, url, *args, **kwargs):
-        logging.info(f"Sending {method} request to {url}")
+        logger.info(
+            f"Sending {method} request to {url}", data={"method": method, "url": url}
+        )
         try:
             response = requests.request(method, url, *args, **kwargs)
             response.raise_for_status()
             return response
 
         except HTTPError as http_err:
-            logging.error(
-                f"HTTP error occurred: {http_err} when sending a {method} to {url} with headers {kwargs.get('headers')}"
+            logger.error(
+                f"HTTP error occurred: {http_err} when sending a {method} request to {url} with headers {kwargs.get('headers')}",
+                http_err,
+                data={
+                    "http_error": http_err,
+                    "method": method,
+                    "url": url,
+                    "headers": kwargs.get("headers"),
+                },
             )
             raise http_err
         except Exception as err:
-            logging.error(
-                f"Other error occurred: {err} when sending a {method} to {url} with headers {kwargs.get('headers')}"
+            logger.error(
+                f"Other error occurred: {err} when sending a {method} to {url} with headers {kwargs.get('headers')}",
+                err,
+                data={
+                    "error": err,
+                    "method": method,
+                    "url": url,
+                    "headers": kwargs.get("headers"),
+                },
             )
             raise err

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -52,10 +52,7 @@ class UploadClient(BaseHttpClient):
         self,
         csv_path: Union[Path, str],
         florence_access_token: str,
-        s3_bucket: str,
-        title: str,
-        collection_id: Optional[str],
-        is_publishable: bool = False,
+        alias_name: Optional[str] = None,
         chunk_size: int = 5242880,
     ) -> Tuple[str, str]:
         """
@@ -67,12 +64,9 @@ class UploadClient(BaseHttpClient):
         """
         self._upload_new(
             csv_path,
-            s3_bucket,
             florence_access_token,
-            title,
             "text/csv",
-            collection_id,
-            is_publishable,
+            alias_name,
             chunk_size,
         )
 
@@ -146,12 +140,9 @@ class UploadClient(BaseHttpClient):
     def _upload_new(
         self,
         file_path: Union[Path, str],
-        s3_bucket: str,
         florence_access_token: str,
-        title: str,
         mimetype: str,
-        collection_id: Optional[str],
-        is_publishable: bool = False,
+        alias_name: Optional[str],
         chunk_size: int = 5242880,
     ) -> Tuple[str, str]:
         """
@@ -170,19 +161,14 @@ class UploadClient(BaseHttpClient):
 
         # Generate upload request params
         upload_params = _generate_upload_new_params(
-            file_path,
-            f"s3://{s3_bucket}",
-            title,
-            mimetype,
-            collection_id,
-            is_publishable,
+            file_path, chunk_size, mimetype, alias_name
         )
 
         # Upload file chunks to S3
         self._upload_file_chunks(file_chunks, upload_params, florence_access_token)
 
         s3_key = upload_params["resumableFilename"]
-        s3_uri = f"s3://{s3_bucket}/{s3_key}"
+        # s3_uri = f"s3://{s3_bucket}/{s3_key}"
 
         # Delete temporary files
         _delete_temp_chunks(file_chunks)
@@ -190,22 +176,28 @@ class UploadClient(BaseHttpClient):
         # TODO Replace print statements with logging
         print("Upload to s3 complete")
 
-        return s3_key, s3_uri
+        return s3_key
 
     def _upload_file_chunks(
-        self, file_chunks: list[str], upload_params: dict, florence_access_token: str
+        self,
+        file_chunks: list[str],
+        upload_params: dict,
+        florence_access_token: str,
     ) -> None:
         """
         Upload file chunks to DP Upload Service with the specified upload parameters.
         """
         chunk_number = 1
         for file_chunk in file_chunks:
+            current_chunk_size = os.path.getsize(Path(file_chunk))
             with open(file_chunk, "rb") as f:
                 # Load file chunk as binary data
                 file = {"file": f}
 
                 # Add chunk number to upload request params
                 upload_params["resumableChunkNumber"] = chunk_number
+
+                upload_params["resumableCurrentChunkSize"] = current_chunk_size
 
                 # Submit `POST` request to `self.upload_url`
                 self.post(
@@ -249,10 +241,9 @@ def _generate_upload_params(file_path: Path, mimetype: str, chunk_size: int) -> 
 
 def _generate_upload_new_params(
     file_path: Path,
-    s3_path: str,
-    title: str,
+    chunk_size: int,
     mimetype: str,
-    collection_id: Optional[str],
+    alias_name: Optional[str],
     is_publishable: bool = False,
     licence: str = "Open Government Licence v3.0",
     licence_url: str = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
@@ -268,24 +259,30 @@ def _generate_upload_new_params(
     # Get filename from csv filepath
     filename = str(file_path).split("/")[-1]
 
-    # Get timestamp to create `resumableFilename` value in `upload_params`
+    # Get timestamp to create `resumableIdentifier` value in `upload_params`
     timestamp = datetime.datetime.now().strftime("%d%m%y%H%M%S")
+
+    # Create identifier from timestamp and filename
+    identifier = f"{timestamp}-{filename.replace('.', '-')}"
+
+    if alias_name is None:
+        alias_name = filename
 
     # Generate upload request params
     upload_params = {
-        "resumableFilename": f"{timestamp}-{filename.replace('.', '-')}",
-        "path": s3_path,
-        "isPublishable": is_publishable,
-        "title": title,
+        "resumableTotalChunks": ceil(total_size / 5242880),
+        "resumableChunkSize": chunk_size,
         "resumableTotalSize": total_size,
         "resumableType": mimetype,
-        "licence": licence,
-        "licenceUrl": licence_url,
-        "resumableTotalChunks": ceil(total_size / 5242880),
+        "resumableIdentifier": identifier,
+        "resumableFilename": filename,
+        "resumableRelativePath": str(file_path),
+        "aliasName": alias_name,
+        "isPublishable": is_publishable,
+        "Licence": licence,
+        "LicenceUrl": licence_url,
+        "Path": f"datasets/{identifier}",
     }
-
-    if collection_id is not None:
-        upload_params["collectionId"] = collection_id
 
     return upload_params
 

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -53,6 +53,7 @@ class UploadClient(BaseHttpClient):
         csv_path: Union[Path, str],
         florence_access_token: str,
         alias_name: Optional[str] = None,
+        title: Optional[str] = None,
         chunk_size: int = 5242880,
     ) -> Tuple[str, str]:
         """
@@ -67,6 +68,7 @@ class UploadClient(BaseHttpClient):
             florence_access_token,
             "text/csv",
             alias_name,
+            title,
             chunk_size,
         )
 
@@ -74,10 +76,8 @@ class UploadClient(BaseHttpClient):
         self,
         sdmx_path: Union[Path, str],
         florence_access_token: str,
-        s3_bucket: str,
-        title: str,
-        collection_id: Optional[str],
-        is_publishable: bool = False,
+        alias_name: Optional[str] = None,
+        title: Optional[str] = None,
         chunk_size: int = 5242880,
     ) -> Tuple[str, str]:
         """
@@ -89,12 +89,10 @@ class UploadClient(BaseHttpClient):
         """
         self._upload_new(
             sdmx_path,
-            s3_bucket,
             florence_access_token,
-            title,
             "application/xml",
-            collection_id,
-            is_publishable,
+            alias_name,
+            title,
             chunk_size,
         )
 
@@ -168,8 +166,7 @@ class UploadClient(BaseHttpClient):
         # Upload file chunks to S3
         self._upload_file_chunks(file_chunks, upload_params, florence_access_token)
 
-        s3_key = upload_params["resumableFilename"]
-        # s3_uri = f"s3://{s3_bucket}/{s3_key}"
+        s3_key = upload_params["Path"]
 
         # Delete temporary files
         _delete_temp_chunks(file_chunks)

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -143,6 +143,7 @@ class UploadClient(BaseHttpClient):
         florence_access_token: str,
         mimetype: str,
         alias_name: Optional[str],
+        title: Optional[str],
         chunk_size: int = 5242880,
     ) -> Tuple[str, str]:
         """
@@ -161,7 +162,7 @@ class UploadClient(BaseHttpClient):
 
         # Generate upload request params
         upload_params = _generate_upload_new_params(
-            file_path, chunk_size, mimetype, alias_name
+            file_path, chunk_size, mimetype, alias_name, title
         )
 
         # Upload file chunks to S3
@@ -243,6 +244,7 @@ def _generate_upload_new_params(
     chunk_size: int,
     mimetype: str,
     alias_name: Optional[str],
+    title: Optional[str],
     is_publishable: bool = False,
     licence: str = "Open Government Licence v3.0",
     licence_url: str = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
@@ -267,6 +269,9 @@ def _generate_upload_new_params(
     if alias_name is None:
         alias_name = filename
 
+    if title is None:
+        title = filename.split(".")[0]
+
     # Generate upload request params
     upload_params = {
         "resumableTotalChunks": ceil(total_size / 5242880),
@@ -277,13 +282,19 @@ def _generate_upload_new_params(
         "resumableFilename": filename,
         "resumableRelativePath": str(file_path),
         "aliasName": alias_name,
-        "isPublishable": is_publishable,
-        "Licence": licence,
-        "LicenceUrl": licence_url,
-        # TODO Currently the POST request is failing due to an potential issue with the Go code (HTTP 500 error: `bad request: unknown error: : duplicate file path`)
-        # Once the Go issue is resolved, check that the Path is in the correct format.
+        # TODO Currently the POST request in `_upload_file_chunks` is failing due to an potential issue with the Go code (HTTP 500 error: `bad request: unknown error: : duplicate file path`)
+        # Once the Go issue is resolved, check that the Path is in the correct format
         # See https://github.com/ONSdigital/dp-api-clients-go/blob/a26491512a8336ad9c31b694c045d8e3a3ed0578/files/client.go#L160
         "Path": f"datasets/{identifier}",
+        "isPublishable": is_publishable,
+        "Title": title,
+        # `SizeInBytes` may be populated from `resumableTotalSize` - check once `Path` issue has been resolved
+        "SizeInBytes": total_size,
+        # `Type` may be populated from `resumableType` - check once `Path` issue has been resolved
+        "Type": mimetype,
+        "Licence": licence,
+        "LicenceUrl": licence_url,
+        # `CollectionID`, `State` and `Etag` fields omitted as not required
     }
 
     return upload_params

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -188,7 +188,7 @@ class UploadClient(BaseHttpClient):
         Upload file chunks to DP Upload Service with the specified upload parameters.
         """
         chunk_number = 1
-        for file_chunk in file_chunks:
+        for idx, file_chunk in enumerate(file_chunks):
             current_chunk_size = os.path.getsize(Path(file_chunk))
             with open(file_chunk, "rb") as f:
                 # Load file chunk as binary data
@@ -196,8 +196,11 @@ class UploadClient(BaseHttpClient):
 
                 # Add chunk number to upload request params
                 upload_params["resumableChunkNumber"] = chunk_number
-
+                upload_params["resumableChunkSize"] = current_chunk_size
                 upload_params["resumableCurrentChunkSize"] = current_chunk_size
+                upload_params["resumableRelativePath"] = (
+                    upload_params["resumableFilename"] + "chunk" + str(idx)
+                )
 
                 # Submit `POST` request to `self.upload_url`
                 self.post(
@@ -271,12 +274,12 @@ def _generate_upload_new_params(
     # Generate upload request params
     upload_params = {
         "resumableTotalChunks": ceil(total_size / 5242880),
-        "resumableChunkSize": chunk_size,
+        # "resumableChunkSize": chunk_size,
         "resumableTotalSize": total_size,
         "resumableType": mimetype,
         "resumableIdentifier": identifier,
         "resumableFilename": filename,
-        "resumableRelativePath": str(file_path),
+        # "resumableRelativePath": str(file_path),
         "aliasName": alias_name,
         "isPublishable": is_publishable,
         "Licence": licence,

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -188,19 +188,15 @@ class UploadClient(BaseHttpClient):
         Upload file chunks to DP Upload Service with the specified upload parameters.
         """
         chunk_number = 1
-        for idx, file_chunk in enumerate(file_chunks):
+        for file_chunk in file_chunks:
             current_chunk_size = os.path.getsize(Path(file_chunk))
             with open(file_chunk, "rb") as f:
                 # Load file chunk as binary data
                 file = {"file": f}
 
-                # Add chunk number to upload request params
+                # Add chunk number and current chunk size to upload request params
                 upload_params["resumableChunkNumber"] = chunk_number
-                upload_params["resumableChunkSize"] = current_chunk_size
                 upload_params["resumableCurrentChunkSize"] = current_chunk_size
-                upload_params["resumableRelativePath"] = (
-                    upload_params["resumableFilename"] + "chunk" + str(idx)
-                )
 
                 # Submit `POST` request to `self.upload_url`
                 self.post(
@@ -274,16 +270,19 @@ def _generate_upload_new_params(
     # Generate upload request params
     upload_params = {
         "resumableTotalChunks": ceil(total_size / 5242880),
-        # "resumableChunkSize": chunk_size,
+        "resumableChunkSize": chunk_size,
         "resumableTotalSize": total_size,
         "resumableType": mimetype,
         "resumableIdentifier": identifier,
         "resumableFilename": filename,
-        # "resumableRelativePath": str(file_path),
+        "resumableRelativePath": str(file_path),
         "aliasName": alias_name,
         "isPublishable": is_publishable,
         "Licence": licence,
         "LicenceUrl": licence_url,
+        # TODO Currently the POST request is failing due to an potential issue with the Go code (HTTP 500 error: `bad request: unknown error: : duplicate file path`)
+        # Once the Go issue is resolved, check that the Path is in the correct format.
+        # See https://github.com/ONSdigital/dp-api-clients-go/blob/a26491512a8336ad9c31b694c045d8e3a3ed0578/files/client.go#L160
         "Path": f"datasets/{identifier}",
     }
 

--- a/dpytools/http/upload.py
+++ b/dpytools/http/upload.py
@@ -6,9 +6,12 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union
 
 from dpytools.http.base import BaseHttpClient
+from dpytools.logging.logger import DpLogger
+
+logger = DpLogger("dpytools")
 
 
-class UploadClient(BaseHttpClient):
+class UploadServiceClient(BaseHttpClient):
     def __init__(self, upload_url: str):
         # Inherit backoff_max value from BaseHTTPClient.__init__
         super().__init__()
@@ -20,13 +23,11 @@ class UploadClient(BaseHttpClient):
         s3_bucket: str,
         florence_access_token: str,
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
         Upload csv files to the DP Upload Service `upload` endpoint. The file to be uploaded (located at `csv_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
 
         The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
-
-        Returns the S3 Object key and S3 URL of the uploaded file.
         """
         self._upload(csv_path, s3_bucket, florence_access_token, "text/csv", chunk_size)
 
@@ -36,13 +37,11 @@ class UploadClient(BaseHttpClient):
         s3_bucket: str,
         florence_access_token: str,
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
         Upload sdmx files to the DP Upload Service `upload` endpoint. The file to be uploaded (located at `sdmx_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
 
         The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
-
-        Returns the S3 Object key and S3 URL of the uploaded file.
         """
         self._upload(
             sdmx_path, s3_bucket, florence_access_token, "application/xml", chunk_size
@@ -55,13 +54,13 @@ class UploadClient(BaseHttpClient):
         alias_name: Optional[str] = None,
         title: Optional[str] = None,
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
         Upload csv files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `csv_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
 
-        The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
+        `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
 
-        Returns the S3 Object key and S3 URL of the uploaded file.
+        `alias_name` and `title` are optional arguments. If these are not explicitly provided, `alias_name` will default to the filename with the extension, and `title` will default to the filename without the extension - e.g. if the filename is "data.csv", `alias_name` defaults to "data.csv" and `title` defaults to "data".
         """
         self._upload_new(
             csv_path,
@@ -79,13 +78,13 @@ class UploadClient(BaseHttpClient):
         alias_name: Optional[str] = None,
         title: Optional[str] = None,
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
         Upload sdmx files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `sdmx_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
 
-        The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
+        `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
 
-        Returns the S3 Object key and S3 URL of the uploaded file.
+        `alias_name` and `title` are optional arguments. If these are not explicitly provided, `alias_name` will default to the filename with the extension, and `title` will default to the filename without the extension - e.g. if the filename is "data.csv", `alias_name` defaults to "data.csv" and `title` defaults to "data".
         """
         self._upload_new(
             sdmx_path,
@@ -103,13 +102,11 @@ class UploadClient(BaseHttpClient):
         florence_access_token: str,
         mimetype: str,
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
-        Upload files to the DP Upload Service `upload` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype`.
+        Upload files to the DP Upload Service `upload` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype` (e.g. "text/csv" for a CSV file).
 
         The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
-
-        Returns the S3 Object key and S3 URL of the uploaded file.
         """
         # Convert file_path string to Path
         if isinstance(file_path, str):
@@ -117,23 +114,24 @@ class UploadClient(BaseHttpClient):
 
         # Create file chunks
         file_chunks = _create_temp_chunks(file_path, chunk_size)
-
+        logger.info("File chunks created", data={"file_chunks": file_chunks})
         # Generate upload request params
         upload_params = _generate_upload_params(file_path, mimetype, chunk_size)
-
+        logger.info(
+            "Upload parameters generated", data={"upload_params": upload_params}
+        )
         # Upload file chunks to S3
         self._upload_file_chunks(file_chunks, upload_params, florence_access_token)
 
-        s3_key = upload_params["resumableIdentifier"]
-        s3_uri = f"s3://{s3_bucket}/{s3_key}"
-
         # Delete temporary files
         _delete_temp_chunks(file_chunks)
-
-        # TODO Replace print statements with logging
-        print("Upload to s3 complete")
-
-        return s3_key, s3_uri
+        logger.info(
+            "Upload to s3 complete",
+            data={
+                "s3_key": upload_params["resumableIdentifier"],
+                "s3_bucket": s3_bucket,
+            },
+        )
 
     def _upload_new(
         self,
@@ -143,13 +141,11 @@ class UploadClient(BaseHttpClient):
         alias_name: Optional[str],
         title: Optional[str],
         chunk_size: int = 5242880,
-    ) -> Tuple[str, str]:
+    ) -> None:
         """
-        Upload files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype`.
+        Upload files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype` (e.g. "text/csv" for a CSV file).
 
-        The `s3_bucket` argument should be set as an environment variable and accessed via os.getenv() or similar. `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
-
-        Returns the S3 Object key and S3 URL of the uploaded file.
+        `florence_access_token` should be generated via the DP Identity API and passed as a string argument.
         """
         # Convert file_path string to Path
         if isinstance(file_path, str):
@@ -157,24 +153,22 @@ class UploadClient(BaseHttpClient):
 
         # Create file chunks
         file_chunks = _create_temp_chunks(file_path, chunk_size)
+        logger.info("File chunks created", data={"file_chunks": file_chunks})
 
         # Generate upload request params
         upload_params = _generate_upload_new_params(
             file_path, chunk_size, mimetype, alias_name, title
         )
+        logger.info(
+            "Upload parameters generated", data={"upload_params": upload_params}
+        )
 
         # Upload file chunks to S3
         self._upload_file_chunks(file_chunks, upload_params, florence_access_token)
 
-        s3_key = upload_params["Path"]
-
         # Delete temporary files
         _delete_temp_chunks(file_chunks)
-
-        # TODO Replace print statements with logging
-        print("Upload to s3 complete")
-
-        return s3_key
+        logger.info("Upload to s3 complete", data={"s3_key": upload_params["Path"]})
 
     def _upload_file_chunks(
         self,
@@ -204,8 +198,13 @@ class UploadClient(BaseHttpClient):
                     files=file,
                     verify=True,
                 )
-                # TODO Replace print statements with logging
-                print(f"File chunk {chunk_number} of {len(file_chunks)} posted")
+                logger.info(
+                    "File chunk posted",
+                    data={
+                        "chunk_number": chunk_number,
+                        "total_chunks": len(file_chunks),
+                    },
+                )
                 chunk_number += 1
 
 
@@ -293,7 +292,6 @@ def _generate_upload_new_params(
         "LicenceUrl": licence_url,
         # `CollectionID`, `State` and `Etag` fields omitted as not required
     }
-
     return upload_params
 
 

--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -106,7 +106,7 @@ class DpLogger:
         Log at the critical level.
 
         event: the thing that's happened, a simple short english statement
-        error: a caught python Exceotion
+        error: a caught python Exception
         raw  : a raw string of any log messages captured for a third party library
         data : arbitrary key-value pairs that may be of use in providing context
         """

--- a/dpytools/slack/slack.py
+++ b/dpytools/slack/slack.py
@@ -1,6 +1,7 @@
-import logging
-
 from dpytools.http.base import BaseHttpClient
+from dpytools.logging.logger import DpLogger
+
+logger = DpLogger("dpytools")
 
 
 class SlackMessenger:
@@ -20,8 +21,8 @@ class SlackMessenger:
         try:
             response = self.http_client.post(self.webhook_url, json=msg_dict)
             response.raise_for_status()
-        except Exception as e:
-            logging.error(f"Failed to send notification: {e}")
+        except Exception as err:
+            logger.error(f"Failed to send notification: {err}", data={"error": err})
 
     def msg_str(self, msg: str):
         """

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -44,15 +44,16 @@ def test_generate_upload_new_params():
     """
     upload_params = _generate_upload_new_params(
         file_path="tests/test_cases/countries.csv",
-        s3_path="s3-path",
+        chunk_size=5242880,
         title="title",
+        alias_name="alias-name",
         mimetype="text/csv",
-        collection_id="collection-id",
     )
-    assert upload_params["path"] == "s3-path"
-    assert upload_params["title"] == "title"
-    assert upload_params["resumableType"] == "text/csv"
-    assert upload_params["collectionId"] == "collection-id"
-    assert upload_params["resumableTotalSize"] == 6198846
     assert upload_params["resumableTotalChunks"] == 2
-    assert "-countries-csv" in upload_params["resumableFilename"]
+    assert upload_params["resumableTotalSize"] == 6198846
+    assert upload_params["resumableType"] == "text/csv"
+    assert "-countries-csv" in upload_params["resumableIdentifier"]
+    assert upload_params["resumableFilename"] == "countries.csv"
+    assert upload_params["resumableRelativePath"] == "tests/test_cases/countries.csv"
+    assert upload_params["aliasName"] == "alias-name"
+    assert upload_params["Title"] == "title"

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -38,7 +38,7 @@ def test_generate_upload_params():
     assert "-countries-csv" in upload_params["resumableIdentifier"]
 
 
-def test_generate_upload_new_params():
+def test_generate_upload_new_params_for_csv():
     """
     Ensures that _generate_upload_new_params() populates the upload_params dict with the correct values
     """
@@ -55,5 +55,23 @@ def test_generate_upload_new_params():
     assert "-countries-csv" in upload_params["resumableIdentifier"]
     assert upload_params["resumableFilename"] == "countries.csv"
     assert upload_params["resumableRelativePath"] == "tests/test_cases/countries.csv"
+    assert upload_params["aliasName"] == "alias-name"
+    assert upload_params["Title"] == "title"
+
+
+def test_generate_new_upload_params_for_sdmx():
+    upload_params = _generate_upload_new_params(
+        file_path="tests/test_cases/test.xml",
+        chunk_size=5242880,
+        mimetype="application/xml",
+        alias_name="alias-name",
+        title="title",
+    )
+    assert upload_params["resumableTotalChunks"] == 1
+    assert upload_params["resumableTotalSize"] == 3895
+    assert upload_params["resumableType"] == "application/xml"
+    assert "-test-xml" in upload_params["resumableIdentifier"]
+    assert upload_params["resumableFilename"] == "test.xml"
+    assert upload_params["resumableRelativePath"] == "tests/test_cases/test.xml"
     assert upload_params["aliasName"] == "alias-name"
     assert upload_params["Title"] == "title"

--- a/tests/test_cases/test.xml
+++ b/tests/test_cases/test.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CompactData xmlns="http://www.SDMX.org/resources/SDMXML/schemas/v2_0/message" xmlns:na_="urn:estat:sdmx.infomodel.keyfamily.KeyFamily=ESTAT:NA_SU:1.12:compact" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.SDMX.org/resources/SDMXML/schemas/v2_0/message SDMXMessage.xsd urn:estat:sdmx.infomodel.keyfamily.KeyFamily=ESTAT:NA_SU:1.12:compact ESTAT_NA_SU_Compact.xsd">
+  <Header>
+    <ID>T1500_2024-01-24T12-58-48</ID>
+    <Test>false</Test>
+    <Name xml:lang="en">ESA2010 Table T1500 Transmission</Name>
+    <Prepared>2024-01-24T12:58:48+00:00</Prepared>
+    <Sender id="GB1">
+      <Name xml:lang="en">Office for National Statistics (United Kingdom)</Name>
+      <Contact><Department xml:lang="en">CORD</Department></Contact>
+    </Sender>
+    <Receiver id="4D0"/>
+    <KeyFamilyRef>NA_SU</KeyFamilyRef>
+    <KeyFamilyAgency>ESTAT</KeyFamilyAgency>
+    <DataSetAgency>ESTAT</DataSetAgency>
+    <DataSetID>T1500</DataSetID>
+    <DataSetAction>Replace</DataSetAction>
+    <Extracted>2024-01-24T12:58:48+00:00</Extracted>
+    <Source xml:lang="en">ONS CORD Database</Source>
+  </Header>
+  <na_:DataSet>
+    <!-- Extracted from Stat. Act: NATP.ESA10.SU\Mode: BlueBook\Dataset: T1500\Status: published\Export Defn: T1500\Run on: 24/01/2024@12:58:48\By: Steve Drew -->
+    <na_:Series ACTIVITY="A01" PRODUCT="CPA_A01" VALUATION="B" COUNTERPART_AREA="W2" CUST_BREAKDOWN="_T" STO="P1" PRICES="V" FREQ="A" REF_AREA="GB" REF_SECTOR="S1" COUNTERPART_SECTOR="S1" ACCOUNTING_ENTRY="C" ACTIVITY_TO="_Z" PRODUCT_TO="_Z" UNIT_MEASURE="XDC" TIME_FORMAT="P1Y" DECIMALS="0" TABLE_IDENTIFIER="T1500" TITLE="Supply table at basic prices including a transformation into purchaser's prices" UNIT_MULT="6" COMPILING_ORG="GB1">
+      <na_:Obs TIME_PERIOD="1997" OBS_VALUE="18415" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="1998" OBS_VALUE="18032" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="1999" OBS_VALUE="17262" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2000" OBS_VALUE="17003" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2001" OBS_VALUE="15844" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2002" OBS_VALUE="18132" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2003" OBS_VALUE="18286" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2004" OBS_VALUE="18650" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2005" OBS_VALUE="16720" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2006" OBS_VALUE="17440" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2007" OBS_VALUE="18475" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2008" OBS_VALUE="21649" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2009" OBS_VALUE="20962" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2010" OBS_VALUE="20762" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2011" OBS_VALUE="23767" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2012" OBS_VALUE="22783" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2013" OBS_VALUE="24310" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2014" OBS_VALUE="25859" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2015" OBS_VALUE="24954" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2016" OBS_VALUE="24488" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2017" OBS_VALUE="25121" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2018" OBS_VALUE="26604" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2019" OBS_VALUE="28246" OBS_STATUS="A" CONF_STATUS="F" />
+      <na_:Obs TIME_PERIOD="2020" OBS_VALUE="27875" OBS_STATUS="A" CONF_STATUS="F" />
+    </na_:Series>
+  </na_:DataSet>
+</CompactData>


### PR DESCRIPTION
### What

Additional mandatory fields added to Upload Service `upload-new` endpoint. There's still an issue with the `Path` parameter, but this is due to a potential problem in the Go code (see comment in `dpytools/http/upload.py` L283-285). This issue has been reported to relevant tech leads for investigation.

### How to review

Hard to test due to the issue mentioned above, but check that all of the fields in [`Resumable`](https://github.com/ONSdigital/dp-upload-service/blob/dfafda9568ac0eb9ff449e3960eb67aa656901c4/upload/upload.go#L19) and [`FileMetadata`](https://github.com/ONSdigital/dp-api-clients-go/blob/main/files/data.go#L3) structs are being added to the request parameters. Use a file that's bigger than 5MB so that you can check it's generating the correct parameters for each chunk.

### Who can review

Anyone.