### PR TITLE
Flush stdout kwarg

### DIFF
--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
@@ -56,7 +56,7 @@ class DpLogger:
         }
 
         self._logger.log(**log_event)
-        
+
         if self.flush_stdout_after_log_entry:
             sys.stdout.flush()
 

--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
@@ -8,12 +9,13 @@ from dpytools.logging.utility import create_error_dict, level_to_severity
 
 
 class DpLogger:
-    def __init__(self, namespace: str):
+    def __init__(self, namespace: str, flush_stdout_after_log_entry: bool = False):
         """
         Simple python logger to create structured logs in keeping
         with https://github.com/ONSdigital/dp-standards/blob/main/LOGGING_STANDARDS.md
 
         namespace: (required) the namespace for the app in question
+        flush_stdout_after_log_entry: (optional) whether to flush the stdout buffer after each log entry
         """
 
         logging.getLogger().addHandler(logging.StreamHandler())
@@ -28,6 +30,7 @@ class DpLogger:
 
         self._logger = structlog.get_logger()
         self.namespace = namespace
+        self.flush_stdout_after_log_entry = flush_stdout_after_log_entry
 
     def _log(
         self,
@@ -53,6 +56,9 @@ class DpLogger:
         }
 
         self._logger.log(**log_event)
+        
+        if self.flush_stdout_after_log_entry:
+            sys.stdout.flush()
 
     def debug(self, event: str, raw: str = None, data: Dict = None):
         """


### PR DESCRIPTION
### What

Added `flush_sdout_after_log_entry` kwag to dp logger. By default it is set to false. when it is set to true it will flush the buffer after each logging statement

Additional Info: "logs are getting concatenated (so 2 or more logging statements can get sent to cloudwatch as a single event via glue). This is messy and will cause a lot of issues if/when we move into the world of logging to elastic search/kibana.
This is happening because more than one log message gets sent to the buffer (memory for standard out) before it gets flushed (printed to console)."

### How to review

check the logic or any typo's

### Who can review

Anyone