### PR TITLE
Added Timestamp to. structlog and flushing after every log

### DIFF
--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -18,12 +18,19 @@ class DpLogger:
         namespace: (required) the namespace for the app in question
         """
 
-        logging.getLogger().addHandler(logging.StreamHandler())
+        class FlushStreamHandler(logging.StreamHandler):
+            def emit(self, record):
+                super().emit(record)
+                self.flush()
 
-        processors = [structlog.processors.JSONRenderer()]
+        handler = FlushStreamHandler()
+        logging.getLogger().addHandler(handler)
 
         structlog.configure(
-            processors=processors,
+            processors=[
+                structlog.processors.TimeStamper(fmt="iso"), 
+                structlog.processors.JSONRenderer()
+            ],
             wrapper_class=structlog.BoundLogger,
             cache_logger_on_first_use=True,
         )


### PR DESCRIPTION
### What

Added Timestamp to dplogger and flushing after every log.

Hypothesis for the Glue logs not separating issue. AWS Glue Job is generating the logs at the same time and the logs are not being flushed 
 
The structlog.processors.TimeStamper processor adds distinct timestamps to each log entry which will help with separating logs additionally added FlushStreamHandler class which will helps ensure that logs won't be batched and combined.
### How to review

Check the logic or is it the right approach.

### Who can review

Anyone