### PR TITLE
DIS-1027 Get pathlike of matching file

### DIFF
--- a/dpytools/stores/directory/local.py
+++ b/dpytools/stores/directory/local.py
@@ -74,6 +74,23 @@ class LocalDirectoryStore(BaseWritableSingleDirectoryStore):
                 f"More than 1 file found that matches the regex pattern '{pattern}' in directory {self.local_path}. Matching: {matching_files}"
             )
 
+    def get_pathlike_of_file_matching(self, pattern: str):
+        """
+        Get the path of the file matching the given pattern, if it exists.
+        """
+        # Assert 1 matching file exists
+        if not self.has_lone_file_matching(pattern):
+            raise FileNotFoundError(
+                f"No matching files found for pattern {pattern} in directory {self.local_path}"
+            )
+        
+        matching_file_name = self._files_that_match_pattern(pattern)[0]
+
+        # Assemble the full path
+        matching_file_full_path = os.path.join(self.local_path, matching_file_name)
+
+        return matching_file_full_path
+
     def save_lone_file_matching(
         self, pattern: str, destination: Optional[Union[Path, str]] = None
     ) -> Path:

--- a/tests/stores/directory/test_local_directory.py
+++ b/tests/stores/directory/test_local_directory.py
@@ -173,6 +173,22 @@ def test_has_lone_file_matching_multiple():
     )
 
 
+def test_get_pathlike_of_file_matching():
+    """
+    Checks that a LocalDirectoryStore can retrieve a lone matching file
+    from a given pattern, then return the full path of the retrieved matching file.
+    """
+
+    test_path = Path(
+        "tests/test_cases/test_local_store/local_directory_folders/local_directory_lone_file"
+    )
+    test_local_directory_store = LocalDirectoryStore(test_path)
+
+    test_matching_file_path_result = test_local_directory_store.get_pathlike_of_file_matching(".json")
+
+    assert test_matching_file_path_result == "tests/test_cases/test_local_store/local_directory_folders/local_directory_lone_file/local_directory_test.json"
+
+
 def test_save_lone_file_destination():
     """
     Checks that a LocalDirectoryStore can retrieve a lone matching file


### PR DESCRIPTION
### What

Added a new function to dp-python-tools that gets the path of the lone file that matches a given pattern in a LocalDirectoryStore. Also added a unit test for the function.

### How to review

See if the function makes sense and does what the ticket requires. Check if the test coverage is adequate.

### Who can review
Anyone