### PR TITLE
2195_Auth_Token

### DIFF
--- a/dpytools/http/token_auth.py
+++ b/dpytools/http/token_auth.py
@@ -58,7 +58,7 @@ class TokenAuth(BaseHttpClient):
             self.refresh_token = response_headers["Refresh"]
             self.token_creation_time = datetime.now()
 
-            self.auth_token = response_headers["Authorization"]
+            self.auth_token = response_headers["Authorization"].split()[1]
             self.id_token = response_headers["ID"]
 
             logger.info(

--- a/tests/http/dataset/test_dataset_api.py
+++ b/tests/http/dataset/test_dataset_api.py
@@ -20,7 +20,7 @@ def setup_mock_token_auth(mock_request):
     mock_token_response.status_code = 201
     mock_token_response.headers = {
         "Refresh": "test_refresh_token",
-        "Authorization": "test_auth_token",
+        "Authorization": "Bearer test_auth_token",
         "ID": "test_id_token",
     }
     mock_request.return_value = mock_token_response

--- a/tests/http/test_base_upload.py
+++ b/tests/http/test_base_upload.py
@@ -13,7 +13,7 @@ def mock_successful_token_response(*args, **kwargs):
     mock_response.status_code = 201
     mock_response.headers = {
         "Refresh": "test_refresh_token",
-        "Authorization": "test_auth_token",
+        "Authorization": "Bearer test_auth_token",
         "ID": "test_id_token",
     }
     return mock_response

--- a/tests/http/test_token_auth.py
+++ b/tests/http/test_token_auth.py
@@ -18,7 +18,7 @@ def test_set_user_tokens():
     mock_response.status_code = 201
     mock_response.headers = {
         "Refresh": "test_refresh_token",
-        "Authorization": "test_auth_token",
+        "Authorization": "Bearer test_auth_token",
         "ID": "test_id_token",
     }
     with patch.object(TokenAuth, "post", return_value=mock_response):
@@ -66,7 +66,7 @@ def test_get_auth_header_with_user_token():
     mock_response.status_code = 201
     mock_response.headers = {
         "Refresh": "test_refresh_token",
-        "Authorization": "test_auth_token",
+        "Authorization": "Bearer test_auth_token",
         "ID": "test_id_token",
     }
     with patch.object(TokenAuth, "post", return_value=mock_response):
@@ -86,7 +86,7 @@ def test_refresh_user_token():
     mock_response = MagicMock()
     mock_response.status_code = 201
     mock_response.headers = {
-        "Authorization": "new_auth_token",
+        "Authorization": "Bearer new_auth_token",
         "ID": "new_id_token",
         "Refresh": "test_refresh_token",
     }
@@ -95,7 +95,7 @@ def test_refresh_user_token():
     ) as mock_put, patch.object(TokenAuth, "post", return_value=mock_response):
         token_auth = TokenAuth()
         token_auth.refresh_user_token()
-        assert token_auth.auth_token == "new_auth_token"
+        assert token_auth.auth_token.split()[1] == "new_auth_token"
         assert token_auth.id_token == "new_id_token"
         assert mock_put.call_count == 1
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Changed the `TokenAuth.set_user_tokens()` to return the auth_token without the `Bearer` part.
changed corresponding test 
### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [ x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

[Provide links to any related issues.](https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=3910&projectKey=DIS&view=detail&selectedIssue=DIS-2195)

### How to review

Anyone