### PR TITLE
Upload client fix

### DIFF
--- a/dpytools/http/README.md
+++ b/dpytools/http/README.md
@@ -115,21 +115,22 @@ upload_client.upload_sdmx("path/to/file.sdmx", chunk_size=1000)
 
 To upload files to the `/upload-new` endpoint, use the `upload_new_csv()` and `upload_new_sdmx()` methods. These methods accept the path to the file and an optional chunk size with a default value of 5242880 bytes (5MB).
 
-The `/upload-new` endpoint also requires an `alias_name` and `title` to be provided in the HTTP request parameters. If these are not explicitly stated in the method call, `alias_name` will default to the filename with the extension, and `title` will default to the filename without the extension.
+The `/upload-new` endpoint also requires an `alias_name`, `title` and `collection_id` to be provided in the HTTP request parameters. If these are not explicitly stated in the method call, `alias_name` will default to the filename with the extension, `title` will default to the filename without the extension, and `collection_id` will default to `collection-id`.
 
 ```python
 from dpytools.http.upload import UploadServiceClient
 
 upload_client = UploadServiceClient("http://example.org/upload-new")
 
-# `alias_name` and `title` arguments not provided, so these values will default to `file.csv` and `file` respectively.
+# `alias_name`, `title` and `collection_id` arguments not provided, so these values will default to `file.csv`, `file` and `collection-id` respectively.
 upload_client.upload_new_csv(
     "path/to/file.csv",)
 
-# `alias_name` and `title` arguments provided, so these values will be set explicitly.
+# `alias_name`, `title` and `collection_id` arguments provided, so these values will be set explicitly.
 upload_client.upload_new_sdmx(
     "path/to/file.sdmx",
     alias_name="my-awesome-file.sdmx",
-    title="My Awesome SDMX File"
+    title="My Awesome SDMX File",
+    collection_id="my-collection-id"
 )
 ```

--- a/dpytools/http/upload/base_upload.py
+++ b/dpytools/http/upload/base_upload.py
@@ -65,6 +65,7 @@ class BaseUploadClient(BaseHttpClient):
         is_publishable: Optional[bool],
         license: Optional[str],
         license_url: Optional[str],
+        collection_id: Optional[str],
     ) -> None:
         """
         Upload files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype` (e.g. "text/csv" for a CSV file).
@@ -87,6 +88,7 @@ class BaseUploadClient(BaseHttpClient):
             is_publishable,
             license,
             license_url,
+            collection_id,
         )
         logger.info(
             "Upload parameters generated", data={"upload_params": upload_params}

--- a/dpytools/http/upload/upload_service_client.py
+++ b/dpytools/http/upload/upload_service_client.py
@@ -61,6 +61,7 @@ class UploadServiceClient(BaseUploadClient):
         title: Optional[str] = None,
         license: Optional[str] = None,
         license_url: Optional[str] = None,
+        collection_id: Optional[str] = None,
     ) -> None:
         """
         Upload csv files to the DP Upload Service `/upload-new` endpoint. The file to be uploaded (located at `csv_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
@@ -76,6 +77,7 @@ class UploadServiceClient(BaseUploadClient):
             is_publishable,
             license,
             license_url,
+            collection_id,
         )
 
     def upload_new_sdmx(
@@ -87,6 +89,7 @@ class UploadServiceClient(BaseUploadClient):
         title: Optional[str] = None,
         license: Optional[str] = None,
         license_url: Optional[str] = None,
+        collection_id: Optional[str] = None,
     ) -> None:
         """
         Upload sdmx files to the DP Upload Service `/upload-new` endpoint. The file to be uploaded (located at `sdmx_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
@@ -102,6 +105,7 @@ class UploadServiceClient(BaseUploadClient):
             is_publishable,
             license,
             license_url,
+            collection_id,
         )
 
     def upload_new_json(
@@ -113,6 +117,7 @@ class UploadServiceClient(BaseUploadClient):
         title: Optional[str] = None,
         license: Optional[str] = None,
         license_url: Optional[str] = None,
+        collection_id: Optional[str] = None,
     ) -> None:
         """
         Upload json files to the DP Upload Service `/upload-new` endpoint. The file to be uploaded (located at `json_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
@@ -128,4 +133,5 @@ class UploadServiceClient(BaseUploadClient):
             is_publishable,
             license,
             license_url,
+            collection_id,
         )

--- a/dpytools/http/upload/utils.py
+++ b/dpytools/http/upload/utils.py
@@ -42,6 +42,7 @@ def _generate_upload_new_params(
     is_publishable: Optional[bool],
     licence: Optional[str],
     licence_url: Optional[str],
+    collection_id: Optional[str],
 ) -> dict:
     """
     Generate request parameters that do not change when iterating through the list of file chunks.
@@ -76,24 +77,29 @@ def _generate_upload_new_params(
             "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         )
 
+    if collection_id is None:
+        collection_id = "collection-id"
+
     # Generate upload request params
     upload_params = {
+        "resumableFilename": filename,
+        "resumableType": mimetype,
         "resumableTotalChunks": ceil(total_size / 5242880),
         "resumableChunkSize": chunk_size,
-        "resumableTotalSize": total_size,
-        "resumableType": mimetype,
-        "resumableIdentifier": identifier,
-        "resumableFilename": filename,
-        "resumableRelativePath": str(file_path),
         "aliasName": alias_name,
-        "Path": f"datasets/{identifier}",
+        "resumableTotalSize": total_size,
+        "resumableIdentifier": identifier,
+        "resumableRelativePath": str(file_path),
+        "LicenceUrl": licence_url,
         "isPublishable": is_publishable,
         "Title": title,
         "SizeInBytes": total_size,
         "Type": mimetype,
         "Licence": licence,
-        "LicenceUrl": licence_url,
-        # `CollectionID`, `State` and `Etag` fields omitted as not required
+        "Path": f"datasets/{identifier}",
+        # TODO: Add collectionId to upload_params from metadata?
+        "collectionId": collection_id,
+        # `State` and `Etag` fields omitted as not required
     }
     return upload_params
 

--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import requests
 import structlog

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,7 +1,6 @@
 import pytest
 
 from dpytools.config.config import Config
-from dpytools.config.properties.base import BaseProperty
 from dpytools.config.properties.intproperty import IntegerProperty
 from dpytools.config.properties.string import StringProperty
 
@@ -65,7 +64,7 @@ def test_config_loader_no_values_error():
         }
     }
     with pytest.raises(AssertionError) as e:
-        config = Config.from_env(config_dictionary)
+        Config.from_env(config_dictionary)
     assert 'Required environment value "MISSING_ENV_VAR" could not be found.' in str(
         e.value
     )
@@ -81,7 +80,7 @@ def test_config_loader_incorrect_type_error(monkeypatch):
         }
     }
     with pytest.raises(TypeError) as e:
-        config = Config.from_env(config_dictionary)
+        Config.from_env(config_dictionary)
     assert (
         "Unsupported property type specified via 'property' field, got <class 'int'>. Should be of type StringProperty or IntegerProperty"
         in str(e.value)
@@ -97,7 +96,7 @@ def test_config_loader_missing_env_var():
         }
     }
     with pytest.raises(AssertionError) as e:
-        config = Config.from_env(config_dictionary)
+        Config.from_env(config_dictionary)
     assert 'Required environment value "MISSING_ENV_VAR" could not be found.' in str(
         e.value
     )
@@ -129,7 +128,7 @@ def test_config_loader_unsupported_property_type(monkeypatch):
         }
     }
     with pytest.raises(TypeError) as e:
-        config = Config.from_env(config_dictionary)
+        Config.from_env(config_dictionary)
     assert (
         "Unsupported property type specified via 'property' field, got <class 'dict'>. Should be of type StringProperty or IntegerProperty"
         in str(e.value)

--- a/tests/config/test_stringproperty.py
+++ b/tests/config/test_stringproperty.py
@@ -100,28 +100,6 @@ def test_string_property_regex_no_match():
     test_property = StringProperty(
         _name="Test String Property",
         _value="Test string value",
-        regex="Test regex",
-        min_len=1,
-        max_len=50,
-    )
-
-    with pytest.raises(ValueError) as e:
-        test_property.secondary_validation()
-
-    assert (
-        "Str value for Test String Property does not match the given regex."
-    ) in str(e.value)
-
-
-def test_string_property_regex_no_match():
-    """
-    Tests if a string property instance with a non-matching regex/value
-    raises the expected error from secondary validation.
-    """
-
-    test_property = StringProperty(
-        _name="Test String Property",
-        _value="Test string value",
         regex="Non-matching regex",
         min_len=1,
         max_len=50,

--- a/tests/http/test_base_upload.py
+++ b/tests/http/test_base_upload.py
@@ -102,6 +102,7 @@ def test_upload_new(
         is_publishable=True,
         license="test_license",
         license_url="http://test_license_url",
+        collection_id="test_collection_id",
     )
 
     mock_create_temp_chunks.assert_called_once_with(
@@ -116,6 +117,7 @@ def test_upload_new(
         True,
         "test_license",
         "http://test_license_url",
+        "test_collection_id",
     )
     mock_upload_file_chunks.assert_called_once_with(
         ["chunk1", "chunk2"], {"Path": "test_path"}

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -51,6 +51,7 @@ def test_generate_upload_new_params_for_csv():
         is_publishable=False,
         licence="My licence",
         licence_url="www.example.org/licence",
+        collection_id="my-collection-id",
     )
     assert upload_params["resumableTotalChunks"] == 2
     assert upload_params["resumableTotalSize"] == 6198846
@@ -62,6 +63,7 @@ def test_generate_upload_new_params_for_csv():
     assert upload_params["Title"] == "title"
     assert upload_params["Licence"] == "My licence"
     assert upload_params["LicenceUrl"] == "www.example.org/licence"
+    assert upload_params["collectionId"] == "my-collection-id"
 
 
 def test_generate_new_upload_params_for_sdmx():

--- a/tests/http/test_upload.py
+++ b/tests/http/test_upload.py
@@ -76,6 +76,7 @@ def test_generate_new_upload_params_for_sdmx():
         is_publishable=False,
         licence="My licence",
         licence_url="www.example.org/licence",
+        collection_id="my-collection-id",
     )
     assert upload_params["resumableTotalChunks"] == 1
     assert upload_params["resumableTotalSize"] == 3895
@@ -87,3 +88,4 @@ def test_generate_new_upload_params_for_sdmx():
     assert upload_params["Title"] == "title"
     assert upload_params["Licence"] == "My licence"
     assert upload_params["LicenceUrl"] == "www.example.org/licence"
+    assert upload_params["collectionId"] == "my-collection-id"

--- a/tests/logging/test_utility.py
+++ b/tests/logging/test_utility.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta
-from unittest import mock
+from datetime import timedelta
 
 from requests import Response
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Requests to the Upload Service were failing - this was because `CollectionID` is now a required parameter. Added this to the `_generate_upload_new_parameters()` function, with a default value of `collection-id` - I think this should eventually populated from the metadata submitted to the pipeline so I've left a TODO comment. The only file with actual changes is `dpytools/http/upload/utils.py` (and associated tests in `test_upload`, `test_base_upload` and `test_utility`) - other changes are from `make fmt` and `make lint`. 

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
No new functionality, so no new tests needed
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [x] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

N/a

### How to review

Sanity check, try generating upload params with and without the `collection_id` argument and check this is being populated.