### PR TITLE
Removed error handling in _handle_request and get_path

### DIFF
--- a/dpytools/http/README.md
+++ b/dpytools/http/README.md
@@ -37,8 +37,6 @@ print(response.json())
 # Prints the response content as JSON
 ```
 
-If the `GET` request fails for a network-related reason, this will raise an `HTTPError`.
-
 #### `post()`
 
 Sends a `POST` request to the specified URL with optional extra arguments.
@@ -67,8 +65,6 @@ response = http_client.post(
     json=dictionary_to_pass
 )
 ```
-
-If the `POST` request fails for a network-related reason, this will raise an `HTTPError`.
 
 #### `put()`
 

--- a/dpytools/http/api/dataset_api_client.py
+++ b/dpytools/http/api/dataset_api_client.py
@@ -31,10 +31,6 @@ class DatasetAPIClient(BaseHttpClient):
             headers=self.token_auth.get_auth_header(),
             verify=True,
         )
-        # if response.status_code != 200:
-        #     raise Exception(
-        #         f"GET request failed with status code: {response.status_code}"
-        #     )
         return response
 
     def post_json(self, json_data: Dict) -> Response:

--- a/dpytools/http/api/dataset_api_client.py
+++ b/dpytools/http/api/dataset_api_client.py
@@ -31,10 +31,10 @@ class DatasetAPIClient(BaseHttpClient):
             headers=self.token_auth.get_auth_header(),
             verify=True,
         )
-        if response.status_code != 200:
-            raise Exception(
-                f"GET request failed with status code: {response.status_code}"
-            )
+        # if response.status_code != 200:
+        #     raise Exception(
+        #         f"GET request failed with status code: {response.status_code}"
+        #     )
         return response
 
     def post_json(self, json_data: Dict) -> Response:

--- a/dpytools/http/base_http.py
+++ b/dpytools/http/base_http.py
@@ -106,36 +106,9 @@ class BaseHttpClient:
         return self._handle_request("PUT", url, *args, **kwargs)
 
     # Method to handle requests
-    def _handle_request(self, method, url, *args, **kwargs):
+    def _handle_request(self, method, url, *args, **kwargs) -> requests.Response:
         logger.info(
             f"Sending {method} request to {url}", data={"method": method, "url": url}
         )
-        try:
-            response = requests.request(method, url, *args, **kwargs)
-            response.raise_for_status()
-            return response
-
-        except HTTPError as http_err:
-            logger.error(
-                f"HTTP error occurred: {http_err} when sending a {method} request to {url} with headers {kwargs.get('headers')}",
-                http_err,
-                data={
-                    "http_error": http_err,
-                    "method": method,
-                    "url": url,
-                    "headers": kwargs.get("headers"),
-                },
-            )
-            raise http_err
-        except Exception as err:
-            logger.error(
-                f"Other error occurred: {err} when sending a {method} to {url} with headers {kwargs.get('headers')}",
-                err,
-                data={
-                    "error": err,
-                    "method": method,
-                    "url": url,
-                    "headers": kwargs.get("headers"),
-                },
-            )
-            raise err
+        response = requests.request(method, url, *args, **kwargs)
+        return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dpytools"
-version = "0.5.1"
+version = "0.5.2"
 description = "Simple reusable python resources for digital publishing"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/tests/http/api/test_dataset_api.py
+++ b/tests/http/api/test_dataset_api.py
@@ -138,18 +138,3 @@ def test_get_path_success(mock_request):
         params={"key": "value"},
         verify=True,
     )
-
-
-@patch("requests.request")
-def test_get_path_failure(mock_request):
-    # Mock the token authentication response
-    mock_token_response = setup_mock_token_auth(mock_request)
-
-    # Setup mock responses to simulate failure
-    mock_response = MagicMock(Response)
-    mock_response.status_code = 404
-    mock_request.side_effect = [mock_token_response, mock_response]
-
-    mock_client = DatasetAPIClient("http://test_url/", "test_path")
-    with pytest.raises(Exception):
-        mock_client.get_path(params={"key": "value"})

--- a/tests/http/test_http.py
+++ b/tests/http/test_http.py
@@ -53,7 +53,7 @@ def test_post(mock_request):
 @patch("requests.request")
 def test_backoff_on_exception(mock_request):
     """
-    Test that the get method retries on HTTPError
+    Test that the post method retries on HTTPError
     """
 
     # Create a mock response object


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Removed error handling in `BaseHttpClient._handle_request()` and `DatasetAPIClient.get_path()` methods, so that this can be handled within the pipeline itself.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
No new functionality
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [x] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

N/a

### How to review

Create a `DatasetAPIClient` with valid/invalid URLs and `dataset_id`s and check that the correct status codes are returned when calling `get_path`.