### PR TITLE
fix(s3): Amend upload to read file only, and as bytes

### DIFF
--- a/dpytools/s3/basic.py
+++ b/dpytools/s3/basic.py
@@ -71,7 +71,7 @@ def upload_local_file_to_s3(
 
     boto3.setup_default_session(profile_name=profile_name)
     bucket_name, key = object_name.split("/", 1)
-    with open(local_file) as f:
+    with open(local_file, "rb") as f:
         client.put_object(Body=f.read(), Bucket=bucket_name, Key=key)
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

When uploading a file to S3, amend it so that reading the local file is:
1. Read only
2. Read as bytes

The current implementation would fail on non-text files, so was failing on files such as `csdb`, `xlsx`, etc.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

Covered in part of integration tests, but should be added here in future.

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### How to review

Try the original method with a local text file (`txt`, `json`, `csv` etc.) and ensure it works. Try the original wiht a binary file (e.g. `csdb`, `xls`, etc.) and verify it fails.

Try the fixed method from this PR with both of the above; both should succeed.