### PR TITLE
check chunk upload response

### DIFF
--- a/dpytools/http/upload/upload_service_client.py
+++ b/dpytools/http/upload/upload_service_client.py
@@ -144,6 +144,7 @@ class UploadServiceClient(BaseHttpClient):
                     files=file,
                     verify=True,
                 )
+                response.raise_for_status()
                 logger.info(
                     "File chunk posted",
                     data={

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -155,6 +155,8 @@ def test_upload_new(
     mock_delete_temp_chunks.assert_called_once_with(["chunk1", "chunk2"])
 
 
+@patch("builtins.open")
+@patch("os.path.getsize")
 @patch("requests.request", side_effect=[
         mock_successful_token_response(), 
         mock_successful_response_chunk_upload(), 
@@ -164,6 +166,8 @@ def test_upload_new(
 )
 def test_upload_file_chunks(
     mock_request,
+    mock_get_pathsize,
+    mock_open_file
 ):
     """
     Ensures that the _upload_file_chunks captures error correctly.

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -141,7 +141,7 @@ def test_upload_file_chunks_fails_http_error(
     mock_upload_file_chunks.side_effect = HTTPError
 
     with pytest.raises(HTTPError):
-        response = client._upload_file_chunks(
+        client._upload_file_chunks(
             mock_create_temp_chunks,
             mock_generate_upload_new_params
         )

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from requests import HTTPError
+import pytest
 
 from dpytools.http.upload.upload_service_client import UploadServiceClient
 
@@ -113,3 +115,33 @@ def test_upload_new(
         ["chunk1", "chunk2"], {"Path": "test_path"}
     )
     mock_delete_temp_chunks.assert_called_once_with(["chunk1", "chunk2"])
+
+
+@patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
+@patch("dpytools.http.upload.upload_service_client._delete_temp_chunks")
+@patch("dpytools.http.upload.upload_service_client._generate_upload_new_params")
+@patch(
+    "dpytools.http.upload.upload_service_client.UploadServiceClient._upload_file_chunks"
+)
+@patch("requests.request", side_effect=mock_successful_token_response)
+def test_upload_file_chunks_fails_http_error(
+    mock_request,
+    mock_upload_file_chunks,
+    mock_generate_upload_new_params,
+    mock_delete_temp_chunks,
+    mock_create_temp_chunks,
+):
+    """
+    Ensures that the _upload_file_chunks captures error correctly.
+    """
+
+    client = UploadServiceClient(upload_url="http://example.com/upload")
+    mock_create_temp_chunks.return_value = ["chunk1", "chunk2"]
+    mock_generate_upload_new_params.return_value = {"Path": "test_path"}
+    mock_upload_file_chunks.side_effect = HTTPError
+
+    with pytest.raises(HTTPError):
+        response = client._upload_file_chunks(
+            mock_create_temp_chunks,
+            mock_generate_upload_new_params
+        )

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -29,13 +29,32 @@ def mock_successful_response_chunk_upload(*args, **kwargs):
 
     return mock_response
 
-
 def mock_bad_response_chunk_upload(*args, **kwargs):
     """
     Mocks a bad response for _upload_file_chunk.
     """
     mock_response = MagicMock()
     mock_response.status_code = 400
+    mock_response.raise_for_status.side_effect = HTTPError
+
+    return mock_response
+
+def mock_get_size_of_chunk_file(*args, **kwargs):
+    """
+    Mocks os.path.getsize
+    """
+    mock_response = MagicMock()
+    mock_response.return_value = 1024
+
+    return mock_response
+
+def mock_open_file(*args, **kwargs):
+    """
+    Mocks builtins.open
+    only returning an empty string as file is only used in POST request, which is being mocked
+    """
+    mock_response = MagicMock()
+    mock_response.return_value = ''
 
     return mock_response
 
@@ -136,19 +155,15 @@ def test_upload_new(
     mock_delete_temp_chunks.assert_called_once_with(["chunk1", "chunk2"])
 
 
-@patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
-@patch("dpytools.http.upload.upload_service_client._generate_upload_new_params")
 @patch("requests.request", side_effect=[
-        mock_successful_token_response, 
-        mock_successful_response_chunk_upload, 
-        mock_successful_response_chunk_upload, 
-        mock_bad_response_chunk_upload
+        mock_successful_token_response(), 
+        mock_successful_response_chunk_upload(), 
+        mock_successful_response_chunk_upload(), 
+        mock_bad_response_chunk_upload()
         ]
 )
 def test_upload_file_chunks(
     mock_request,
-    mock_generate_upload_new_params,
-    mock_create_temp_chunks,
 ):
     """
     Ensures that the _upload_file_chunks captures error correctly.
@@ -159,13 +174,15 @@ def test_upload_file_chunks(
     os.environ["IDENTITY_API_URL"] = "http://test_url"
 
     client = UploadServiceClient(upload_url="http://example.com/upload")
-    mock_create_temp_chunks.return_value = ["chunk1", "chunk2"]
-    mock_generate_upload_new_params.return_value = {"Path": "test_path"}
+
+    temp_chunk = ["chunk1", "chunk2"]
+    # only need an empty dict for upload_params
+    upload_params = {}
 
     # expecting a succesful upload from first call of _upload_file_chunks
     response = client._upload_file_chunks(
-        mock_create_temp_chunks,
-        mock_generate_upload_new_params
+        temp_chunk,
+        upload_params
     )
 
     assert response.status_code == 201
@@ -173,6 +190,6 @@ def test_upload_file_chunks(
     # expecting a failed upload from second call of _upload_file_chunks
     with pytest.raises(HTTPError):
         client._upload_file_chunks(
-            mock_create_temp_chunks,
-            mock_generate_upload_new_params
+            temp_chunk,
+            upload_params
         )

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -160,11 +160,10 @@ def test_upload_new(
 @patch("requests.request", side_effect=[
         mock_successful_token_response(), 
         mock_successful_response_chunk_upload(), 
-        mock_successful_response_chunk_upload(), 
-        mock_bad_response_chunk_upload()
+        mock_successful_response_chunk_upload()
         ]
 )
-def test_upload_file_chunks(
+def test_upload_file_chunks_success(
     mock_request,
     mock_get_pathsize,
     mock_open_file
@@ -183,7 +182,7 @@ def test_upload_file_chunks(
     # only need an empty dict for upload_params
     upload_params = {}
 
-    # expecting a succesful upload from first call of _upload_file_chunks
+    # expecting a succesful upload from _upload_file_chunks
     response = client._upload_file_chunks(
         temp_chunk,
         upload_params
@@ -191,7 +190,34 @@ def test_upload_file_chunks(
 
     assert response.status_code == 201
     
-    # expecting a failed upload from second call of _upload_file_chunks
+
+@patch("builtins.open")
+@patch("os.path.getsize")
+@patch("requests.request", side_effect=[
+        mock_successful_token_response(),
+        mock_bad_response_chunk_upload()
+        ]
+)
+def test_upload_file_chunks_failure(
+    mock_request,
+    mock_get_pathsize,
+    mock_open_file
+):
+    """
+    Ensures that the _upload_file_chunks captures error correctly.
+    """
+
+    os.environ["FLORENCE_USER"] = "test_user"
+    os.environ["FLORENCE_PASSWORD"] = "test_password"
+    os.environ["IDENTITY_API_URL"] = "http://test_url"
+
+    client = UploadServiceClient(upload_url="http://example.com/upload")
+
+    temp_chunk = ["chunk1", "chunk2"]
+    # only need an empty dict for upload_params
+    upload_params = {}
+    
+    # expecting a failed upload from _upload_file_chunks
     with pytest.raises(HTTPError):
         client._upload_file_chunks(
             temp_chunk,

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -138,8 +138,7 @@ def test_upload_new(
 
 @patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
 @patch("dpytools.http.upload.upload_service_client._generate_upload_new_params")
-@patch(
-    "requests.request", side_effect=[
+@patch("requests.request", side_effect=[
         mock_successful_token_response, 
         mock_successful_response_chunk_upload, 
         mock_successful_response_chunk_upload, 

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -20,6 +20,25 @@ def mock_successful_token_response(*args, **kwargs):
     }
     return mock_response
 
+def mock_successful_response_chunk_upload(*args, **kwargs):
+    """
+    Mocks a successful response for _upload_file_chunk.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+
+    return mock_response
+
+
+def mock_bad_response_chunk_upload(*args, **kwargs):
+    """
+    Mocks a bad response for _upload_file_chunk.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+
+    return mock_response
+
 
 @patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
 @patch("dpytools.http.upload.upload_service_client._delete_temp_chunks")
@@ -118,28 +137,41 @@ def test_upload_new(
 
 
 @patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
-@patch("dpytools.http.upload.upload_service_client._delete_temp_chunks")
 @patch("dpytools.http.upload.upload_service_client._generate_upload_new_params")
 @patch(
-    "dpytools.http.upload.upload_service_client.UploadServiceClient._upload_file_chunks"
+    "requests.request", side_effect=[
+        mock_successful_token_response, 
+        mock_successful_response_chunk_upload, 
+        mock_successful_response_chunk_upload, 
+        mock_bad_response_chunk_upload
+        ]
 )
-@patch("requests.request", side_effect=mock_successful_token_response)
-def test_upload_file_chunks_fails_http_error(
+def test_upload_file_chunks(
     mock_request,
-    mock_upload_file_chunks,
     mock_generate_upload_new_params,
-    mock_delete_temp_chunks,
     mock_create_temp_chunks,
 ):
     """
     Ensures that the _upload_file_chunks captures error correctly.
     """
 
+    os.environ["FLORENCE_USER"] = "test_user"
+    os.environ["FLORENCE_PASSWORD"] = "test_password"
+    os.environ["IDENTITY_API_URL"] = "http://test_url"
+
     client = UploadServiceClient(upload_url="http://example.com/upload")
     mock_create_temp_chunks.return_value = ["chunk1", "chunk2"]
     mock_generate_upload_new_params.return_value = {"Path": "test_path"}
-    mock_upload_file_chunks.side_effect = HTTPError
 
+    # expecting a succesful upload from first call of _upload_file_chunks
+    response = client._upload_file_chunks(
+        mock_create_temp_chunks,
+        mock_generate_upload_new_params
+    )
+
+    assert response.status_code == 201
+    
+    # expecting a failed upload from second call of _upload_file_chunks
     with pytest.raises(HTTPError):
         client._upload_file_chunks(
             mock_create_temp_chunks,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Added a response check after each chunk is posted to the upload api. Currently each POST is treated as a success.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Provide links to any related issues.

### How to review

Sanity check