### PR TITLE
feat: Add response content to log + fix upload service client path param

### DIFF
--- a/dpytools/http/upload/upload_service_client.py
+++ b/dpytools/http/upload/upload_service_client.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Optional, Union
 
-from requests import Response
+from requests import HTTPError, Response
 
 from dpytools.http.base_http import BaseHttpClient
 from dpytools.http.token_auth import TokenAuth
@@ -10,21 +10,15 @@ from dpytools.http.upload.utils import (
     _create_temp_chunks,
     _delete_temp_chunks,
     _generate_upload_new_params,
-    _generate_upload_params,
 )
 from dpytools.logging.logger import DpLogger
 
-# Dev note:
-
-# At time of writing (17/5/2024) there are two endpoints supported
-# by the Upload Service:
-# 1. /upload
-# 2. /upload-new
-
-# Putting aside the wisdom of "upload-new" we do need to support both of
-# these options so have by necessity adopted this nomenclature.
-
 logger = DpLogger("dpytools")
+
+
+class UploadFileResult:
+    def __init__(self, path: str):
+        self.path = path
 
 
 class UploadServiceClient(BaseHttpClient):
@@ -32,49 +26,19 @@ class UploadServiceClient(BaseHttpClient):
         self.token_auth = TokenAuth()
         self.upload_url = upload_url
 
-    def upload(
-        self, file_path: Union[Path, str], mimetype: str, chunk_size: int = 5242880
-    ) -> Response:
-        """
-        Upload files to the DP Upload Service `/upload` endpoint. A file of type `mimetype` (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket.
-        """
-        # Convert file_path string to Path
-        if isinstance(file_path, str):
-            file_path = Path(file_path).absolute()
-
-        # Create file chunks
-        file_chunks = _create_temp_chunks(file_path, chunk_size)
-        logger.info("File chunks created", data={"file_chunks": file_chunks})
-        # Generate upload request params
-        upload_params = _generate_upload_params(file_path, mimetype, chunk_size)
-        logger.info(
-            "Upload parameters generated", data={"upload_params": upload_params}
-        )
-        # Upload file chunks to S3
-        self._upload_file_chunks(file_chunks, upload_params)
-
-        # Delete temporary files
-        _delete_temp_chunks(file_chunks)
-        logger.info(
-            "Upload to s3 complete",
-            data={
-                "s3_key": upload_params["resumableIdentifier"],
-            },
-        )
-
     def upload_new(
         self,
         file_path: Union[Path, str],
         mimetype: str,
-        chunk_size: Optional[int] = 5242880,
+        upload_path: str,
+        identifier: str,
+        chunk_size: int = 5242880,
         alias_name: Optional[str] = None,
         title: Optional[str] = None,
-        is_publishable: Optional[bool] = False,
-        licence: Optional[str] = "Open Government Licence v3.0",
-        licence_url: Optional[
-            str
-        ] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-        collection_id: Optional[str] = "collection-id",
+        is_publishable: bool = False,
+        licence: str = "Open Government Licence v3.0",
+        licence_url: str = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+        collection_id: str = "collection-id",
     ) -> Response:
         """
         Upload files to the DP Upload Service `upload-new` endpoint. The file to be uploaded (located at `file_path`) is chunked (default chunk size 5242880 bytes) and uploaded to an S3 bucket. The file type should be specified as `mimetype` (e.g. "text/csv" for a CSV file). The remainder of the optional arguments are required for the request to the `/upload-new` endpoint to succeed. If these are not specified, defaults are set in the `_generate_upload_new_params` function call.
@@ -104,18 +68,28 @@ class UploadServiceClient(BaseHttpClient):
             licence,
             licence_url,
             collection_id,
+            upload_path,
+            identifier,
         )
         logger.info(
             "Upload parameters generated", data={"upload_params": upload_params}
         )
+        try:
+            # Upload file chunks to S3
+            response = self._upload_file_chunks(file_chunks, upload_params)
 
-        # Upload file chunks to S3
-        response = self._upload_file_chunks(file_chunks, upload_params)
-
-        # Delete temporary files
-        _delete_temp_chunks(file_chunks)
-        logger.info("Upload to s3 complete", data={"s3_key": upload_params["Path"]})
-        return response
+            # Delete temporary files
+            _delete_temp_chunks(file_chunks)
+            logger.info("Upload to s3 complete", data={"s3_key": upload_params["Path"]})
+            return response
+        except HTTPError as e:
+            logger.error(
+                "Error uploading file",
+                e,
+                response=e.response,
+                data={"upload_params": upload_params},
+            )
+            raise e
 
     def _upload_file_chunks(
         self,
@@ -126,6 +100,7 @@ class UploadServiceClient(BaseHttpClient):
         Upload file chunks to DP Upload Service with the specified upload parameters.
         """
         chunk_number = 1
+        response: Response = Response()
         for file_chunk in file_chunks:
             current_chunk_size = os.path.getsize(Path(file_chunk))
             with open(file_chunk, "rb") as f:
@@ -137,14 +112,28 @@ class UploadServiceClient(BaseHttpClient):
                 upload_params["resumableCurrentChunkSize"] = current_chunk_size
 
                 # Submit `POST` request to `self.upload_url`
-                response = self.post(
-                    self.upload_url,
-                    headers=self.token_auth.get_auth_header(),
-                    params=upload_params,
-                    files=file,
-                    verify=True,
-                )
-                response.raise_for_status()
+                try:
+                    response = self.post(
+                        self.upload_url,
+                        headers=self.token_auth.get_auth_header(),
+                        params=upload_params,
+                        files=file,
+                        verify=True,
+                    )
+
+                    if response.status_code > 299:
+                        response.raise_for_status()
+                except HTTPError as e:
+                    logger.error(
+                        "Error posting chunk to upload service",
+                        e,
+                        data={
+                            "upload_params": upload_params,
+                            "chunk_number": chunk_number,
+                        },
+                    )
+                    raise e
+
                 logger.info(
                     "File chunk posted",
                     data={

--- a/dpytools/http/upload/utils.py
+++ b/dpytools/http/upload/utils.py
@@ -1,35 +1,7 @@
 import os
-from datetime import datetime
 from math import ceil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
-
-def _generate_upload_params(file_path: Path, mimetype: str, chunk_size: int) -> dict:
-    """
-    Generate request parameters that do not change when iterating through the list of file chunks.
-
-    To be used with the `upload` endpoint.
-    """
-    # Get total size of file to be uploaded
-    total_size = os.path.getsize(file_path)
-
-    # Get filename from csv filepath
-    filename = str(file_path).split("/")[-1]
-
-    # Get timestamp to create `resumableIdentifier` value in `POST` params
-    timestamp = datetime.now().strftime("%d%m%y%H%M%S")
-
-    # Generate upload request params
-    upload_params = {
-        "resumableTotalChunks": ceil(total_size / chunk_size),
-        "resumableChunkSize": chunk_size,
-        "resumableTotalSize": total_size,
-        "resumableType": mimetype,
-        "resumableIdentifier": f"{timestamp}-{filename.replace('.', '-')}",
-        "resumableFilename": filename,
-    }
-    return upload_params
 
 
 def _generate_upload_new_params(
@@ -42,6 +14,8 @@ def _generate_upload_new_params(
     licence: str,
     licence_url: str,
     collection_id: str,
+    upload_path: str,
+    identifier: str,
 ) -> dict:
     """
     Generate request parameters that do not change when iterating through the list of file chunks.
@@ -51,15 +25,10 @@ def _generate_upload_new_params(
     # Get total size of file to be uploaded
     total_size = os.path.getsize(file_path)
 
-    # Get timestamp to create `resumableIdentifier` value in `upload_params`
-    timestamp = datetime.now().strftime("%d%m%y%H%M%S")
-
-    # Create identifier from timestamp and filename
-    identifier = f"{timestamp}-{file_path.name.replace('.', '-')}"
-
+    file_name = file_path.name.replace(" ", "_")
     # Generate upload request params
     upload_params = {
-        "resumableFilename": file_path.name,
+        "resumableFilename": file_name,
         "resumableType": mimetype,
         "resumableTotalChunks": ceil(total_size / chunk_size),
         "resumableChunkSize": chunk_size,
@@ -70,10 +39,9 @@ def _generate_upload_new_params(
         "LicenceUrl": licence_url,
         "isPublishable": is_publishable,
         "Title": title,
-        "SizeInBytes": total_size,
         "Type": mimetype,
         "Licence": licence,
-        "Path": f"datasets/{identifier}",
+        "Path": upload_path,
         # TODO: Get collectionId from metadata?
         "collectionId": collection_id,
     }

--- a/dpytools/logging/logger.py
+++ b/dpytools/logging/logger.py
@@ -4,7 +4,7 @@ import sys
 from datetime import datetime, timezone
 from typing import Dict, Optional
 
-import requests
+from requests import Response
 import structlog
 
 from dpytools.logging.data_exception import DataException
@@ -73,8 +73,8 @@ class DpLogger:
         level,
         error: Optional[Exception] = None,
         data: Optional[Dict] = None,
-        raw: str = None,
-        response: Optional[requests.Response] = None,
+        raw: Optional[str] = None,
+        response: Optional[Response] = None,
     ):
         data_dict = data if data is not None else {}
         data_dict["level"] = logging.getLevelName(level)
@@ -82,23 +82,7 @@ class DpLogger:
         # Match DP logging structure
         # https://github.com/ONSdigital/dp-standards/blob/main/LOGGING_STANDARDS.md
 
-        if response is not None:
-            r_dict = {
-                "method": response.request.method,
-                "scheme": get_scheme(response.url),
-                "host": get_domain(response.url),
-                "port": get_port(response.url),
-                "path": response.request.path_url,
-                "status_code": response.status_code,
-                "started_at": get_start_date(response.headers["Date"]),
-                "ended_at": get_end_date(response.elapsed, response.headers["Date"]),
-                "duration": calculate_duration_in_nanoseconds(
-                    response.elapsed, response.headers["Date"]
-                ),
-                "response_content_length": len(response.content),
-            }
-        else:
-            r_dict = None
+        r_dict = self._get_response_log_data(response)
 
         errors, data_dict = self.get_error_and_data_dicts(error, data_dict)
 
@@ -118,9 +102,29 @@ class DpLogger:
         if self.flush_stdout_after_log_entry:
             sys.stdout.flush()
 
+    def _get_response_log_data(self, response: Optional[Response]):
+        if response is None:
+            return None
+
+        return {
+            "method": response.request.method,
+            "scheme": get_scheme(response.url),
+            "host": get_domain(response.url),
+            "port": get_port(response.url),
+            "path": response.request.path_url,
+            "status_code": response.status_code,
+            "started_at": get_start_date(response.headers["Date"]),
+            "ended_at": get_end_date(response.elapsed, response.headers["Date"]),
+            "duration": calculate_duration_in_nanoseconds(
+                response.elapsed, response.headers["Date"]
+            ),
+            "response_content_length": len(response.content),
+            "response_content": response.content,
+        }
+
     def get_error_and_data_dicts(
         self, error: Optional[Exception], data_dict: Optional[dict]
-    ) -> tuple[dict, dict]:
+    ) -> tuple[Optional[dict], Optional[dict]]:
         """
         Converts error (if any)to dictionary, and adds additional error data from the exception to the data dictionary
 
@@ -145,9 +149,9 @@ class DpLogger:
     def debug(
         self,
         event: str,
-        raw: str = None,
-        data: Dict = None,
-        response: requests.Response = None,
+        raw: Optional[str] = None,
+        data: Optional[Dict] = None,
+        response: Optional[Response] = None,
     ):
         """
         Log at the debug level.
@@ -162,9 +166,9 @@ class DpLogger:
     def info(
         self,
         event: str,
-        raw: str = None,
-        data: Dict = None,
-        response: requests.Response = None,
+        raw: Optional[str] = None,
+        data: Optional[Dict] = None,
+        response: Optional[Response] = None,
     ):
         """
         Log at the info level.
@@ -173,14 +177,14 @@ class DpLogger:
         :param raw: Raw log data for a third party library.
         :param data: Additional context data such as arbitrary key-value pairs that may be of use in providing context.
         """
-        self._log(event, logging.INFO, raw=raw, data=data)
+        self._log(event, logging.INFO, response=response, raw=raw, data=data)
 
     def warning(
         self,
         event: str,
-        raw: str = None,
-        data: Dict = None,
-        response: requests.Response = None,
+        raw: Optional[str] = None,
+        data: Optional[Dict] = None,
+        response: Optional[Response] = None,
     ):
         """
         Log at the warning level.
@@ -196,9 +200,9 @@ class DpLogger:
         self,
         event: str,
         error: Exception,
-        raw: str = None,
-        data: Dict = None,
-        response: requests.Response = None,
+        raw: Optional[str] = None,
+        data: Optional[Dict] = None,
+        response: Optional[Response] = None,
     ):
         """
         Log at the error level.
@@ -217,9 +221,9 @@ class DpLogger:
         self,
         event: str,
         error: Exception,
-        raw: str = None,
-        data: Dict = None,
-        response: requests.Response = None,
+        raw: Optional[str] = None,
+        data: Optional[Dict] = None,
+        response: Optional[Response] = None,
     ):
         """
         IMPORTANT: You should only be logging at the critical level during

--- a/dpytools/logging/utility.py
+++ b/dpytools/logging/utility.py
@@ -1,7 +1,7 @@
 import sys
 import traceback
 from datetime import datetime, timedelta
-from typing import Dict, List
+from typing import Dict
 from urllib.parse import urlparse
 
 from requests import Response
@@ -22,7 +22,7 @@ def level_to_severity(level: int) -> int:
         return 3
 
 
-def create_error_dict(error: Exception) -> List[Dict]:
+def create_error_dict(error: Exception) -> Dict:
     """
     Take a python Exception and create a sub dict/document
     matching DP logging standards expression of a captured
@@ -34,7 +34,7 @@ def create_error_dict(error: Exception) -> List[Dict]:
     tb = traceback.extract_tb(error.__traceback__)
 
     if not tb:
-        return [{"error_message": str(error), "error_trace": ""}]
+        return {"error_message": str(error), "error_trace": ""}
 
     # Get the last exception where exceptions are chained.
     last_call = tb[-1]
@@ -52,8 +52,7 @@ def create_error_dict(error: Exception) -> List[Dict]:
         "data": {"full": formatted_traceback},
     }
 
-    # Listify in keeping with expected DP logging structures
-    return [error_dict]
+    return error_dict
 
 
 def get_scheme(url: str) -> str:
@@ -104,7 +103,7 @@ def get_end_date(time_delta: timedelta, date: str) -> str:
     return end_date.isoformat() + "Z"
 
 
-def calculate_duration_in_nanoseconds(time_delta: timedelta, date: str) -> int:
+def calculate_duration_in_nanoseconds(time_delta: timedelta, date: str) -> float:
     """This function will calculate the duration in nanoseconds."""
     strp_time = datetime.strptime(date, "%a, %d %b %Y %H:%M:%S GMT")
     end_date = strp_time + time_delta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dpytools"
-version = "0.12.0"
+version = "0.13.0"
 description = "Simple reusable Python resources for digital publishing"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/tests/http/upload/test_upload_service_client.py
+++ b/tests/http/upload/test_upload_service_client.py
@@ -20,6 +20,7 @@ def mock_successful_token_response(*args, **kwargs):
     }
     return mock_response
 
+
 def mock_successful_response_chunk_upload(*args, **kwargs):
     """
     Mocks a successful response for _upload_file_chunk.
@@ -28,6 +29,7 @@ def mock_successful_response_chunk_upload(*args, **kwargs):
     mock_response.status_code = 201
 
     return mock_response
+
 
 def mock_bad_response_chunk_upload(*args, **kwargs):
     """
@@ -39,6 +41,7 @@ def mock_bad_response_chunk_upload(*args, **kwargs):
 
     return mock_response
 
+
 def mock_get_size_of_chunk_file(*args, **kwargs):
     """
     Mocks os.path.getsize
@@ -48,54 +51,16 @@ def mock_get_size_of_chunk_file(*args, **kwargs):
 
     return mock_response
 
+
 def mock_open_file(*args, **kwargs):
     """
     Mocks builtins.open
     only returning an empty string as file is only used in POST request, which is being mocked
     """
     mock_response = MagicMock()
-    mock_response.return_value = ''
+    mock_response.return_value = ""
 
     return mock_response
-
-
-@patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
-@patch("dpytools.http.upload.upload_service_client._delete_temp_chunks")
-@patch("dpytools.http.upload.upload_service_client._generate_upload_params")
-@patch(
-    "dpytools.http.upload.upload_service_client.UploadServiceClient._upload_file_chunks"
-)
-@patch("requests.request", side_effect=mock_successful_token_response)
-def test_upload(
-    mock_request,
-    mock_upload_file_chunks,
-    mock_generate_upload_params,
-    mock_delete_temp_chunks,
-    mock_create_temp_chunks,
-):
-    """
-    Ensures that the _upload method works correctly.
-    """
-    os.environ["FLORENCE_USER"] = "test_user"
-    os.environ["FLORENCE_PASSWORD"] = "test_password"
-    os.environ["IDENTITY_API_URL"] = "http://test_url"
-
-    client = UploadServiceClient(upload_url="http://example.com/upload")
-    mock_create_temp_chunks.return_value = ["chunk1", "chunk2"]
-    mock_generate_upload_params.return_value = {"resumableIdentifier": "test_id"}
-
-    client.upload(file_path="tests/test_cases/countries.csv", mimetype="text/csv")
-
-    mock_create_temp_chunks.assert_called_once_with(
-        Path("tests/test_cases/countries.csv").absolute(), 5242880
-    )
-    mock_generate_upload_params.assert_called_once_with(
-        Path("tests/test_cases/countries.csv").absolute(), "text/csv", 5242880
-    )
-    mock_upload_file_chunks.assert_called_once_with(
-        ["chunk1", "chunk2"], {"resumableIdentifier": "test_id"}
-    )
-    mock_delete_temp_chunks.assert_called_once_with(["chunk1", "chunk2"])
 
 
 @patch("dpytools.http.upload.upload_service_client._create_temp_chunks")
@@ -122,7 +87,8 @@ def test_upload_new(
     client = UploadServiceClient(upload_url="http://example.com/upload")
     mock_create_temp_chunks.return_value = ["chunk1", "chunk2"]
     mock_generate_upload_new_params.return_value = {"Path": "test_path"}
-
+    identifier = "test-id"
+    upload_path = "/datasets/identifier-filename"
     client.upload_new(
         file_path="tests/test_cases/countries.csv",
         mimetype="text/csv",
@@ -133,6 +99,8 @@ def test_upload_new(
         licence="test_licence",
         licence_url="http://test_licence_url",
         collection_id="test_collection_id",
+        identifier=identifier,
+        upload_path=upload_path,
     )
 
     mock_create_temp_chunks.assert_called_once_with(
@@ -148,6 +116,8 @@ def test_upload_new(
         "test_licence",
         "http://test_licence_url",
         "test_collection_id",
+        upload_path,
+        identifier,
     )
     mock_upload_file_chunks.assert_called_once_with(
         ["chunk1", "chunk2"], {"Path": "test_path"}
@@ -157,17 +127,15 @@ def test_upload_new(
 
 @patch("builtins.open")
 @patch("os.path.getsize")
-@patch("requests.request", side_effect=[
-        mock_successful_token_response(), 
-        mock_successful_response_chunk_upload(), 
-        mock_successful_response_chunk_upload()
-        ]
+@patch(
+    "requests.request",
+    side_effect=[
+        mock_successful_token_response(),
+        mock_successful_response_chunk_upload(),
+        mock_successful_response_chunk_upload(),
+    ],
 )
-def test_upload_file_chunks_success(
-    mock_request,
-    mock_get_pathsize,
-    mock_open_file
-):
+def test_upload_file_chunks_success(mock_request, mock_get_pathsize, mock_open_file):
     """
     Ensures that the _upload_file_chunks captures error correctly.
     """
@@ -183,26 +151,18 @@ def test_upload_file_chunks_success(
     upload_params = {}
 
     # expecting a succesful upload from _upload_file_chunks
-    response = client._upload_file_chunks(
-        temp_chunk,
-        upload_params
-    )
+    response = client._upload_file_chunks(temp_chunk, upload_params)
 
     assert response.status_code == 201
-    
+
 
 @patch("builtins.open")
 @patch("os.path.getsize")
-@patch("requests.request", side_effect=[
-        mock_successful_token_response(),
-        mock_bad_response_chunk_upload()
-        ]
+@patch(
+    "requests.request",
+    side_effect=[mock_successful_token_response(), mock_bad_response_chunk_upload()],
 )
-def test_upload_file_chunks_failure(
-    mock_request,
-    mock_get_pathsize,
-    mock_open_file
-):
+def test_upload_file_chunks_failure(mock_request, mock_get_pathsize, mock_open_file):
     """
     Ensures that the _upload_file_chunks captures error correctly.
     """
@@ -216,10 +176,7 @@ def test_upload_file_chunks_failure(
     temp_chunk = ["chunk1", "chunk2"]
     # only need an empty dict for upload_params
     upload_params = {}
-    
+
     # expecting a failed upload from _upload_file_chunks
     with pytest.raises(HTTPError):
-        client._upload_file_chunks(
-            temp_chunk,
-            upload_params
-        )
+        client._upload_file_chunks(temp_chunk, upload_params)

--- a/tests/http/upload/test_upload_utils.py
+++ b/tests/http/upload/test_upload_utils.py
@@ -5,7 +5,6 @@ from dpytools.http.upload.utils import (
     _create_temp_chunks,
     _delete_temp_chunks,
     _generate_upload_new_params,
-    _generate_upload_params,
 )
 
 
@@ -14,7 +13,7 @@ def test_create_and_delete_temp_chunks():
     Ensures that _create_temp_chunks() creates the correct number of file chunks and that _delete_temp_chunks() deletes the temporary files.
     """
     temp_file_paths_list = _create_temp_chunks(
-        file_path="tests/test_cases/countries.csv"
+        file_path=Path("tests/test_cases/countries.csv")
     )
     assert len(temp_file_paths_list) == 2
     assert "temp-file-part-1" in temp_file_paths_list[0]
@@ -22,26 +21,12 @@ def test_create_and_delete_temp_chunks():
     assert os.path.exists(Path(temp_file_paths_list[0]).absolute()) is False
 
 
-def test_generate_upload_params():
-    """
-    Ensures that _generate_upload_params() populates the upload_params dict with the correct values
-    """
-    upload_params = _generate_upload_params(
-        file_path="tests/test_cases/countries.csv",
-        mimetype="text/csv",
-        chunk_size=5242880,
-    )
-    assert upload_params["resumableTotalChunks"] == 2
-    assert upload_params["resumableTotalSize"] == 6198846
-    assert upload_params["resumableType"] == "text/csv"
-    assert upload_params["resumableFilename"] == "countries.csv"
-    assert "-countries-csv" in upload_params["resumableIdentifier"]
-
-
 def test_generate_upload_new_params_for_csv():
     """
     Ensures that _generate_upload_new_params() populates the upload_params dict with the correct values
     """
+    identifier = "test-id"
+    upload_path = "test/upload/path/here"
     upload_params = _generate_upload_new_params(
         file_path=Path("tests/test_cases/countries.csv"),
         mimetype="text/csv",
@@ -52,11 +37,13 @@ def test_generate_upload_new_params_for_csv():
         licence="My licence",
         licence_url="www.example.org/licence",
         collection_id="my-collection-id",
+        identifier=identifier,
+        upload_path=upload_path,
     )
     assert upload_params["resumableTotalChunks"] == 2
     assert upload_params["resumableTotalSize"] == 6198846
     assert upload_params["resumableType"] == "text/csv"
-    assert "-countries-csv" in upload_params["resumableIdentifier"]
+    assert upload_params["resumableIdentifier"] == identifier
     assert upload_params["resumableFilename"] == "countries.csv"
     assert upload_params["resumableRelativePath"] == "tests/test_cases/countries.csv"
     assert upload_params["aliasName"] == "alias-name"
@@ -64,28 +51,4 @@ def test_generate_upload_new_params_for_csv():
     assert upload_params["Licence"] == "My licence"
     assert upload_params["LicenceUrl"] == "www.example.org/licence"
     assert upload_params["collectionId"] == "my-collection-id"
-
-
-def test_generate_new_upload_params_for_sdmx():
-    upload_params = _generate_upload_new_params(
-        file_path=Path("tests/test_cases/test.xml"),
-        mimetype="application/xml",
-        chunk_size=5242880,
-        alias_name="alias-name",
-        title="title",
-        is_publishable=False,
-        licence="My licence",
-        licence_url="www.example.org/licence",
-        collection_id="my-collection-id",
-    )
-    assert upload_params["resumableTotalChunks"] == 1
-    assert upload_params["resumableTotalSize"] == 3895
-    assert upload_params["resumableType"] == "application/xml"
-    assert "-test-xml" in upload_params["resumableIdentifier"]
-    assert upload_params["resumableFilename"] == "test.xml"
-    assert upload_params["resumableRelativePath"] == "tests/test_cases/test.xml"
-    assert upload_params["aliasName"] == "alias-name"
-    assert upload_params["Title"] == "title"
-    assert upload_params["Licence"] == "My licence"
-    assert upload_params["LicenceUrl"] == "www.example.org/licence"
-    assert upload_params["collectionId"] == "my-collection-id"
+    assert upload_params["Path"] == upload_path

--- a/tests/logging/test_logger.py
+++ b/tests/logging/test_logger.py
@@ -126,14 +126,14 @@ def test_error_log_complex(logger: DpLogger, capfd):
         assert log["raw"] == raw, _view_log(log)
         assert log["data"]["level"] == "ERROR", _view_log(log)
         assert log["data"]["ghostbusters"] == data["ghostbusters"], _view_log(log)
-        assert log["errors"][0]["message"] == err_message, _view_log(log)
-        assert log["errors"][0]["stack_trace"]["file"].endswith("test_logger.py"), (
+        assert log["errors"]["message"] == err_message, _view_log(log)
+        assert log["errors"]["stack_trace"]["file"].endswith("test_logger.py"), (
             _view_log(log)
         )
-        assert log["errors"][0]["stack_trace"]["line"] == 118, _view_log(log)
-        assert (
-            log["errors"][0]["stack_trace"]["function"] == "test_error_log_complex"
-        ), _view_log(log)
+        assert log["errors"]["stack_trace"]["line"] == 118, _view_log(log)
+        assert log["errors"]["stack_trace"]["function"] == "test_error_log_complex", (
+            _view_log(log)
+        )
 
 
 def test_error_handles_dataexception(logger: DpLogger, capfd):
@@ -154,13 +154,13 @@ def test_error_handles_dataexception(logger: DpLogger, capfd):
         assert log["severity"] == 1, _view_log(log)
         assert log["raw"] == raw, _view_log(log)
         assert log["data"]["level"] == "ERROR"
-        assert log["errors"][0]["message"] == err_message, _view_log(log)
-        assert log["errors"][0]["stack_trace"]["file"].endswith("test_logger.py"), (
+        assert log["errors"]["message"] == err_message, _view_log(log)
+        assert log["errors"]["stack_trace"]["file"].endswith("test_logger.py"), (
             _view_log(log)
         )
-        assert log["errors"][0]["stack_trace"]["line"] == 147, _view_log(log)
+        assert log["errors"]["stack_trace"]["line"] == 147, _view_log(log)
         assert (
-            log["errors"][0]["stack_trace"]["function"]
+            log["errors"]["stack_trace"]["function"]
             == "test_error_handles_dataexception"
         ), _view_log(log)
 
@@ -193,11 +193,11 @@ def test_critical_log_complex(logger: DpLogger, capfd):
         assert log["raw"] == raw, _view_log(log)
         assert log["data"]["level"] == "CRITICAL", _view_log(log)
         assert log["data"]["ghostbusters"] == data["ghostbusters"], _view_log(log)
-        assert log["errors"][0]["message"] == err_message, _view_log(log)
-        assert log["errors"][0]["stack_trace"]["file"].endswith("test_logger.py"), (
+        assert log["errors"]["message"] == err_message, _view_log(log)
+        assert log["errors"]["stack_trace"]["file"].endswith("test_logger.py"), (
             _view_log(log)
         )
-        assert log["errors"][0]["stack_trace"]["line"] == 185, _view_log(log)
+        assert log["errors"]["stack_trace"]["line"] == 185, _view_log(log)
         assert (
-            log["errors"][0]["stack_trace"]["function"] == "test_critical_log_complex"
+            log["errors"]["stack_trace"]["function"] == "test_critical_log_complex"
         ), _view_log(log)

--- a/tests/logging/test_utility.py
+++ b/tests/logging/test_utility.py
@@ -28,13 +28,13 @@ def test_create_error_dict():
         raise ValueError("Test error")
     except Exception as e:
         error_dict = create_error_dict(e)
-        assert error_dict[0]["message"] == "Test error"
-        assert "stack_trace" in error_dict[0]
-        assert "file" in error_dict[0]["stack_trace"]
-        assert "function" in error_dict[0]["stack_trace"]
-        assert "line" in error_dict[0]["stack_trace"]
-        assert "data" in error_dict[0]
-        assert "full" in error_dict[0]["data"]
+        assert error_dict["message"] == "Test error"
+        assert "stack_trace" in error_dict
+        assert "file" in error_dict["stack_trace"]
+        assert "function" in error_dict["stack_trace"]
+        assert "line" in error_dict["stack_trace"]
+        assert "data" in error_dict
+        assert "full" in error_dict["data"]
 
 
 def test_get_scheme():


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

#### Upload service client

1. Remove unused code for the old `upload` route
2. Remove logic for the path and identifier; this is now passed into the `upload_new` method
3. Improve error handling

#### Logging

1. Fix a load of typing issues
2. Log response content if response was passed into methods
3. Actually use the `response` object from the parameter in the `info()` method

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Provide links to any related issues.

### How to review

Describe the steps required to test the changes.